### PR TITLE
Check if installed when layer-inespecific adapters are called

### DIFF
--- a/src/senaite/patient/__init__.py
+++ b/src/senaite/patient/__init__.py
@@ -52,6 +52,6 @@ def check_installed(default_return):
         def wrapper(*args, **kwargs):
             if not is_installed():
                 return default_return
-            return func(args, **kwargs)
+            return func(*args, **kwargs)
         return wrapper
     return is_installed_decorator

--- a/src/senaite/patient/__init__.py
+++ b/src/senaite/patient/__init__.py
@@ -19,7 +19,8 @@
 # Some rights reserved, see README and LICENSE.
 
 import logging
-
+from bika.lims.api import get_request
+from senaite.patient.interfaces import ISenaitePatientLayer
 from zope.i18nmessageid import MessageFactory
 
 PRODUCT_NAME = "senaite.patient"
@@ -34,3 +35,23 @@ logger = logging.getLogger(PRODUCT_NAME)
 def initialize(context):
     """Initializer called when used as a Zope 2 product."""
     logger.info("*** Initializing SENAITE PATIENT Customization package ***")
+
+
+def is_installed():
+    """Returns whether the product is installed or not
+    """
+    request = get_request()
+    return ISenaitePatientLayer.providedBy(request)
+
+
+def check_installed(default_return):
+    """Decorator to prevent the function to be called if product not installed
+    :param default_return: value to return if not installed
+    """
+    def is_installed_decorator(func):
+        def wrapper(*args, **kwargs):
+            if not is_installed():
+                return default_return
+            return func(args, **kwargs)
+        return wrapper
+    return is_installed_decorator

--- a/src/senaite/patient/adapters/guards.py
+++ b/src/senaite/patient/adapters/guards.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims.interfaces import IGuardAdapter
+from senaite.patient import check_installed
 from zope.interface import implements
 
 
@@ -28,6 +29,7 @@ class SampleGuardAdapter(object):
     def __init__(self, context):
         self.context = context
 
+    @check_installed(True)
     def guard(self, action):
         func_name = "guard_{}".format(action)
         func = getattr(self, func_name, None)

--- a/src/senaite/patient/adapters/listing.py
+++ b/src/senaite/patient/adapters/listing.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from plone.memoize.instance import memoize
+from senaite.patient import check_installed
 from senaite.patient import messageFactory as _
 from senaite.app.listing.interfaces import IListingView
 from senaite.app.listing.interfaces import IListingViewAdapter
@@ -67,6 +68,7 @@ class SamplesListingAdapter(object):
     def icon_tag(self, name, **kwargs):
         return self.senaite_theme.icon_tag(name, **kwargs)
 
+    @check_installed(None)
     def folder_item(self, obj, item, index):
         if obj.isMedicalRecordTemporary:
             # Add an icon after the sample ID
@@ -74,8 +76,8 @@ class SamplesListingAdapter(object):
             kwargs = {"width": 16, "title": _("Temporary MRN")}
             after_icons += self.icon_tag("id-card-red", **kwargs)
             item["after"].update({"getId": after_icons})
-        return item
 
+    @check_installed(None)
     def before_render(self):
         # Add review_states
         for status in ADD_STATUSES:


### PR DESCRIPTION
This PR ensures that adapters are only called if `senaite.patient` is installed (active). The following traceback arises otherwise:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 215, in __call__
  Module senaite.app.listing.ajax, line 108, in handle_subpath
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 533, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 312, in get_folderitems
  Module senaite.app.listing.view, line 903, in folderitems
  Module senaite.patient.adapters.listing, line 71, in folder_item
AttributeError: 'RequestContainer' object has no attribute 'isMedicalRecordTemporary'
```