### PR TITLE
Add check_installed decorator to subscribers

### DIFF
--- a/src/senaite/patient/subscribers/__init__.py
+++ b/src/senaite/patient/subscribers/__init__.py
@@ -1,22 +1,2 @@
 # -*- coding: utf-8 -*-
-#
-# This file is part of SENAITE.CORE.
-#
-# SENAITE.CORE is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by the Free Software
-# Foundation, version 2.
-#
-# This program is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
-# details.
-#
-# You should have received a copy of the GNU General Public License along with
-# this program; if not, write to the Free Software Foundation, Inc., 51
-# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#
-# Copyright 2018-2020 by it's authors.
-# Some rights reserved, see README and LICENSE.
 
-from bika.lims.workflow import skip
-from bika.lims.workflow import doActionFor

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -3,9 +3,11 @@
 from bika.lims import api
 from DateTime import DateTime
 from senaite.patient import api as patient_api
+from senaite.patient import check_installed
 from senaite.patient import logger
 
 
+@check_installed(None)
 def on_object_created(instance, event):
     """Event handler when a sample was created
     """
@@ -13,6 +15,7 @@ def on_object_created(instance, event):
     update_patient(instance)
 
 
+@check_installed(None)
 def on_object_edited(instance, event):
     """Event handler when a sample was edited
     """

--- a/src/senaite/patient/subscribers/configure.zcml
+++ b/src/senaite/patient/subscribers/configure.zcml
@@ -1,7 +1,5 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:browser="http://namespaces.zope.org/browser"
-    xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="senaite.patient">
   
   <!-- Sample modified -->


### PR DESCRIPTION
This Pull Request adds the `check_installed` decorator to subscribers so they are not called unless `senaite.patient` add-on is installed/active.

Traceback on Sample creation without this PR and with `senaite.patient` add-on not active:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module bika.lims.browser.analysisrequest.add2, line 67, in decorator
  Module bika.lims.browser.analysisrequest.add2, line 739, in __call__
  Module bika.lims.browser.analysisrequest.add2, line 1691, in ajax_submit
  Module bika.lims.utils.analysisrequest, line 84, in create_analysisrequest
  Module Products.Archetypes.BaseObject, line 685, in processForm
  Module zope.event, line 32, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 619, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 619, in subscribers
  Module senaite.patient.subscribers.analysisrequest, line 12, in on_object_created
  Module senaite.patient.subscribers.analysisrequest, line 32, in handle_age_and_birthdate
AttributeError: 'NoneType' object has no attribute 'get'
```