### PR TITLE
Omit required attribute if patient is optional

### DIFF
--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/temporaryidentifierwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/temporaryidentifierwidget.pt
@@ -98,7 +98,7 @@
                  tal:attributes="id string:${fieldName}_value;
                                  value python:value_temp and value_auto or value;
                                  disabled value_temp|nothing;
-                                 required required|nothing;"/>
+                                 required python:required and 'required' or None"/>
         </div>
 
         <!-- Temporary checkbox -->


### PR DESCRIPTION
## Description

The `required` attribute flags simply by it's existance if empty form submission is allowed or not.
Therefore, `required="True"` or `required="False"` are both required.

This PR ensures that the required attribute is absent in the MRN field from the sample header view if the patient is optional for samples.