### PR TITLE
Added "MRN" and "Patient" columns in Samples listing

### DIFF
--- a/src/senaite/patient/setuphandlers.py
+++ b/src/senaite/patient/setuphandlers.py
@@ -57,6 +57,8 @@ INDEXES = [
 # Tuples of (catalog, column_name)
 COLUMNS = [
     (CATALOG_ANALYSIS_REQUEST_LISTING, "isMedicalRecordTemporary"),
+    (CATALOG_ANALYSIS_REQUEST_LISTING, "getMedicalRecordNumberValue"),
+    (CATALOG_ANALYSIS_REQUEST_LISTING, "getPatientFullName"),
     (PATIENT_CATALOG, "mrn"),
 ]
 


### PR DESCRIPTION
This Pull Request adds the columns "MRN" (Medical Record Number) and "Patient" (patient's fullname) in Samples listing. It also added these two as metadata fields on samples' catalog so user can search by them too.