### PR TITLE
Allow/disallow to verify/publish samples with temporary MRN

### DIFF
--- a/src/senaite/patient/adapters/guards.py
+++ b/src/senaite/patient/adapters/guards.py
@@ -41,12 +41,22 @@ class SampleGuardAdapter(object):
         return True
 
     def guard_verify(self):
-        """Returns true if the Medical Record Number is not temporary
+        """Returns whether the sample can be verified
         """
         temp_mrn = self.context.isMedicalRecordTemporary()
         if temp_mrn:
             # Check whether users can verify samples with a temporary MRN
             if not api.get_registry_record("senaite.patient.verify_temp_mrn"):
+                return False
+
+        return True
+
+    def guard_publish(self):
+        """Returns whether the sample can be published
+        """
+        temp_mrn = self.context.isMedicalRecordTemporary()
+        if temp_mrn:
+            if not api.get_registry_record("senaite.patient.publish_temp_mrn"):
                 return False
 
         return True

--- a/src/senaite/patient/adapters/guards.py
+++ b/src/senaite/patient/adapters/guards.py
@@ -18,6 +18,7 @@
 # Copyright 2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from bika.lims.interfaces import IGuardAdapter
 from senaite.patient import check_installed
 from zope.interface import implements
@@ -42,4 +43,10 @@ class SampleGuardAdapter(object):
     def guard_verify(self):
         """Returns true if the Medical Record Number is not temporary
         """
-        return not self.context.isMedicalRecordTemporary()
+        temp_mrn = self.context.isMedicalRecordTemporary()
+        if temp_mrn:
+            # Check whether users can verify samples with a temporary MRN
+            if not api.get_registry_record("senaite.patient.verify_temp_mrn"):
+                return False
+
+        return True

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -14,6 +14,7 @@ class IPatientControlPanel(Interface):
     require_patient = schema.Bool(
         title=_(u"Require Patient"),
         description=_("Require Patients in Samples"),
+        required=False,
         default=True,
     )
 
@@ -21,14 +22,18 @@ class IPatientControlPanel(Interface):
         title=_(u"Allow to verify samples with a temporary MRN"),
         description=_(u"If selected, users will be able to verify samples "
                       u"that have a Patient assigned with a temporary Medical "
-                      u"Record Number (MRN).")
+                      u"Record Number (MRN)."),
+        required=False,
+        default=False,
     )
 
     publish_temp_mrn = schema.Bool(
         title=_(u"Allow to publish samples with a temporary MRN"),
         description=_(u"If selected, users will be able to publish samples "
                       u"that have a Patient assigned with a temporary Medical "
-                      u"Record Number (MRN).")
+                      u"Record Number (MRN)."),
+        required=False,
+        default=False,
     )
 
 

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -17,6 +17,20 @@ class IPatientControlPanel(Interface):
         default=True,
     )
 
+    verify_temp_mrn = schema.Bool(
+        title=_(u"Allow to verify samples with a temporary MRN"),
+        description=_(u"If selected, users will be able to verify samples "
+                      u"that have a Patient assigned with a temporary Medical "
+                      u"Record Number (MRN).")
+    )
+
+    publish_temp_mrn = schema.Bool(
+        title=_(u"Allow to publish samples with a temporary MRN"),
+        description=_(u"If selected, users will be able to publish samples "
+                      u"that have a Patient assigned with a temporary Medical "
+                      u"Record Number (MRN).")
+    )
+
 
 class PatientControlPanelForm(RegistryEditForm):
     schema = IPatientControlPanel

--- a/src/senaite/patient/configure.zcml
+++ b/src/senaite/patient/configure.zcml
@@ -37,6 +37,7 @@
   <include package=".content" />
   <include package=".monkeys" />
   <include package=".subscribers" />
+  <include package=".upgrade" />
 
   <!-- Default profile -->
   <genericsetup:registerProfile

--- a/src/senaite/patient/upgrade/__init__.py
+++ b/src/senaite/patient/upgrade/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.PATIENT.
+#
+# SENAITE.PATIENT is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020-2021 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/patient/upgrade/configure.zcml
+++ b/src/senaite/patient/upgrade/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="senaite.patient">
+
+<genericsetup:upgradeStep
+        title="Upgrade to SENAITE PATIENT 1.0.0"
+        source="1.0.0"
+        destination="1.0.0"
+        handler="senaite.patient.upgrade.v01_00_000.upgrade"
+        profile="senaite.patient:default"/>
+
+</configure>

--- a/src/senaite/patient/upgrade/v01_00_000.py
+++ b/src/senaite/patient/upgrade/v01_00_000.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.PATIENT.
+#
+# SENAITE.PATIENT is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020-2021 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from senaite.patient import logger
+from senaite.patient.config import PRODUCT_NAME
+from senaite.patient.setuphandlers import PROFILE_ID
+from senaite.core.upgrade import upgradestep
+from senaite.core.upgrade.utils import UpgradeUtils
+
+version = "1.0.0"
+
+
+@upgradestep(PRODUCT_NAME, version)
+def upgrade(tool):
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    ut = UpgradeUtils(portal)
+    ver_from = ut.getInstalledVersion(PRODUCT_NAME)
+
+    if ut.isOlderVersion(PRODUCT_NAME, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+            PRODUCT_NAME, ver_from, version))
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(PRODUCT_NAME, ver_from,
+                                                   version))
+
+    # -------- ADD YOUR STUFF BELOW --------
+
+    # Allow/Disallow to verify/publish samples with temporary MRN
+    setup.runImportStepFromProfile(PROFILE_ID, "plone.app.registry")
+
+    logger.info("{0} upgraded to version {1}".format(PRODUCT_NAME, version))
+    return True


### PR DESCRIPTION
This Pull Request adds these two additional settings in senaite patient's control panel:

-  Allow to verify samples with a temporary MRN (checkbox)
   If selected, users will be able to verify samples that have a Patient assigned with a temporary Medical Record Number (MRN).

- Allow to publish samples with a temporary MRN (checkbox) 
  If selected, users will be able to publish samples that have a Patient assigned with a temporary Medical Record Number (MRN). 