### PR TITLE
Added marker interface for patients

### DIFF
--- a/src/senaite/patient/catalog/indexers.py
+++ b/src/senaite/patient/catalog/indexers.py
@@ -20,7 +20,7 @@
 
 from bika.lims.interfaces import IAnalysisRequest
 from plone.indexer import indexer
-from senaite.patient.content.patient import IPatient
+from senaite.patient.interfaces import IPatient
 
 
 @indexer(IAnalysisRequest)

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -16,13 +16,14 @@ from senaite.patient import api as patient_api
 from senaite.patient import messageFactory as _
 from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.config import GENDERS
+from senaite.patient.interfaces import IPatient
 from zope import schema
 from zope.interface import Invalid
 from zope.interface import implementer
 from zope.interface import invariant
 
 
-class IPatient(model.Schema):
+class IPatientSchema(model.Schema):
     """Patient Content
     """
 
@@ -165,7 +166,7 @@ class IPatient(model.Schema):
             raise Invalid(_("Patient email is invalid"))
 
 
-@implementer(IPatient)
+@implementer(IPatient, IPatientSchema)
 class Patient(Item):
     """Results Interpretation Template content
     """

--- a/src/senaite/patient/interfaces.py
+++ b/src/senaite/patient/interfaces.py
@@ -20,6 +20,7 @@
 
 from senaite.core.interfaces import ISenaiteCatalogObject
 from senaite.lims.interfaces import ISenaiteLIMS
+from zope.interface import interface
 
 
 class ISenaitePatientLayer(ISenaiteLIMS):
@@ -32,4 +33,9 @@ class ISenaitePatientLayer(ISenaiteLIMS):
 
 class IPatientCatalog(ISenaiteCatalogObject):
     """Marker interface for Patient Catalog
+    """
+
+
+class IPatient(interface.Interface):
+    """Marker interface for Patients
     """

--- a/src/senaite/patient/profiles/default/types/Patient.xml
+++ b/src/senaite/patient/profiles/default/types/Patient.xml
@@ -44,7 +44,7 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">senaite.patient.content.patient.IPatient</property>
+  <property name="schema">senaite.patient.content.patient.IPatientSchema</property>
   <property name="klass">senaite.patient.content.patient.Patient</property>
 
   <!-- Dexterity behaviours for this type -->

--- a/src/senaite/patient/upgrade/v01_00_000.py
+++ b/src/senaite/patient/upgrade/v01_00_000.py
@@ -64,6 +64,8 @@ def upgrade(tool):
 
     # Allow/Disallow to verify/publish samples with temporary MRN
     setup.runImportStepFromProfile(PROFILE_ID, "plone.app.registry")
+    # Update schema interface
+    setup.runImportStepFromProfile(PROFILE_ID, "typeinfo")
 
     # https://github.com/senaite/senaite.patient/pull/14
     migrate_to_patient_catalog(portal)


### PR DESCRIPTION
## Description

This PR makes `IPatient` a marker interface for patient object and renames the schema interface to `IPatientSchema`.

This is required to create proper adapters for patient objects.