### PR TITLE
Convert DoB widget to native date input field

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- #19 Convert DoB widget to native date input field
 - #17 Added marker interface for patients
 - #14 Compatibility with Senaite catalog migration
 - #8 Added patient workflow and managed permissions

--- a/src/senaite/patient/browser/widgets.py
+++ b/src/senaite/patient/browser/widgets.py
@@ -133,6 +133,8 @@ class AgeDoBWidget(DateTimeWidget):
 
             # Calculate the DoB
             dob = patient_api.get_birth_date(ymd)
+        elif value.get("selector") == "dob":
+            self.default_age = False
 
         return dob, {}
 

--- a/src/senaite/patient/content/analysisrequest.py
+++ b/src/senaite/patient/content/analysisrequest.py
@@ -105,6 +105,8 @@ DateOfBirthField = ExtDateTimeField(
         label=_("Age / Date of birth"),
         render_own_label=True,
         default_age=True,
+        show_time=False,
+        datepicker_nofuture=True,
         visible={
             'add': 'edit',
         }

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -104,12 +104,13 @@
                tal:attributes="id string:${fieldName}_dob_controls">
             <div class="form-row">
               <div class="form-group">
-                <input type="text"
-                       class="datepicker_nofuture"
-                       tal:attributes="id string:${subfield_dob};
+                <input type="date"
+                       class="form-control form-control-sm"
+                       tal:attributes="python:widget.attrs();
+                                       id string:${subfield_dob};
                                        name string:${subfield_dob};
                                        required python:required and 'required' or None;
-                                       value python: widget.ulocalized_gmt0_time(value, context=context, request=request) if value else '';"/>
+                                       value python: widget.to_local_date(value, context=context, request=request) if value else '';"/>
               </div>
             </div>
 

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -23,7 +23,8 @@ def on_object_edited(instance, event):
     if field_name in request.form:
         dob_field = instance.getField(field_name)
         dob = dob_field.widget.process_form(instance, dob_field, request.form)
-        dob_field.set(instance, dob[0])
+        if dob is not None:
+            dob_field.set(instance, dob[0])
 
     update_patient(instance)
 


### PR DESCRIPTION
## Description

This PR converts the DoB widget to a native `<input="date" ... />` field.
This makes it compatible with https://github.com/senaite/senaite.core/pull/1892 