### PR TITLE
Improve widget markup

### DIFF
--- a/src/senaite/patient/browser/widgets.py
+++ b/src/senaite/patient/browser/widgets.py
@@ -133,6 +133,7 @@ class AgeDoBWidget(DateTimeWidget):
 
             # Calculate the DoB
             dob = patient_api.get_birth_date(ymd)
+            self.default_age = True
         elif value.get("selector") == "dob":
             self.default_age = False
 

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -20,9 +20,6 @@
 
     <metal:edit_macro define-macro="edit">
       <tal:values define="value python:field.getEditAccessor(here)() or None;
-                          session_value python:here.session_restore_value(fieldName, value);
-                          cached_value python:request.get(fieldName, session_value);
-                          value python:cached_value or value;
                           subfield_years string:${fieldName}.years:ignore_empty:record;
                           subfield_months string:${fieldName}.months:ignore_empty:record;
                           subfield_days string:${fieldName}.days:ignore_empty:record;

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -42,7 +42,7 @@
           <div class="fieldErrorBox" tal:condition="required"></div>
 
           <!-- Age / DoB toggle radio -->
-          <div class="form-group mb-0">
+          <div class="form-group mb-0 text-left">
             <!-- age selector -->
             <input
               type="radio"

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -38,94 +38,82 @@
 
         <div class="field AgeDoBWidget"
              tal:attributes="data-required python:required and '1' or '0';
-                             data-fieldname string:${fieldName}">
+                    data-fieldname string:${fieldName}">
           <div class="fieldErrorBox" tal:condition="required"></div>
 
           <!-- Age / DoB toggle radio -->
-          <div class="form form-inline">
-            <div class="form-group">
-              <input tal:attributes="id string:${fieldName}_age_selector;
-                                     name string:${subfield_selector}"
-                     tal:condition="age_selected"
-                     type="radio" value="age" checked/>
-              <input tal:attributes="id string:${fieldName}_age_selector;
-                                     name string:${subfield_selector}"
-                     tal:condition="not:age_selected"
-                     type="radio" value="age"/>&nbsp;
-              <label tal:attributes="for string:${fieldName}_age_selector;">Age</label>
-              &nbsp;&nbsp;
-              <input tal:attributes="id string:${fieldName}_dob_selector;
-                                     name string:${subfield_selector}"
-                     tal:condition="not:age_selected"
-                     type="radio" value="dob" checked/>
-              <input tal:attributes="id string:${fieldName}DateOfBirth_dob_selector;
-                                     name string:${subfield_selector}"
-                     tal:condition="age_selected"
-                     type="radio" value="dob"/>&nbsp;
-              <label tal:attributes="for string:${fieldName}_dob_selector">Date of Birth</label>
-              &nbsp;&nbsp;
-            </div>
+          <div class="form-group mb-0">
+            <!-- age selector -->
+            <input
+              type="radio"
+              value="age"
+              tal:attributes="id string:${fieldName}_age_selector;
+                    checked python:age_selected;
+                    name string:${subfield_selector}" />
+            <label tal:attributes="for string:${fieldName}_age_selector;">Age</label>
+
+            <!-- dob selector -->
+            <input
+              type="radio"
+              value="dob"
+              tal:attributes="id string:${fieldName}DateOfBirth_dob_selector;
+                    checked python:not age_selected;
+                    name string:${subfield_selector}" />
+            <label tal:attributes="for string:${fieldName}_dob_selector">Date of Birth</label>
+
           </div>
 
           <!-- Age input area -->
-          <div class="form form-inline"
+          <div class="input-group"
+               style="max-width: 260px;"
                tal:attributes="id string:${fieldName}_age_controls">
-            <div class="form-row">
-              <div class="form-group col-md-3">
-                <label tal:attributes="for string:${subfield_years}"
-                       i18n:translate="" class="small">Years</label>
-                <input type="number" size='2' min='0' max='150'
-                       class="form-control-sm"
-                       tal:attributes="id string:${subfield_years};
-                                       name string:${subfield_years};
-                                       value years;
-                                       required python:required and 'required' or None;"/>
-              </div>
-              <div class="form-group col-md-3">
-                <label tal:attributes="for string:${subfield_months}"
-                       i18n:translate="" class="small">Months</label>
-                <input type="number" size='2' value='' min='0' max='12'
-                       class="form-control-sm"
-                       tal:attributes="id string:${subfield_months};
-                                       name string:${subfield_months};
-                                       value months;"/>
-              </div>
-              <div class="form-group col-md-3">
-                <label tal:attributes="for string:${subfield_days}"
-                       i18n:translate="" class="small">Days</label>
-                <input type="number" size='2' value='' min='0' max='31'
-                       class="form-control-sm"
-                       tal:attributes="id string:${subfield_days};
-                                       name string:${subfield_days};
-                                       value days;"/>
-              </div>
-            </div>
+            <input type="number" min='0' max='150'
+                   class="form-control form-control-sm"
+                   title="Years"
+                   placeholder="Years"
+                   i18n:attributes="placeholder title"
+                   tal:attributes="id string:${subfield_years};
+                         name string:${subfield_years};
+                         value years;
+                         required python:required and 'required' or None;"/>
+            <input type="number" value='' min='0' max='12'
+                   class="form-control form-control-sm"
+                   title="Months"
+                   placeholder="Months"
+                   i18n:attributes="placeholder title"
+                   tal:attributes="id string:${subfield_months};
+                         name string:${subfield_months};
+                         value months;"/>
+            <input type="number" value='' min='0' max='31'
+                   class="form-control form-control-sm"
+                   title="Days"
+                   placeholder="Days"
+                   i18n:attributes="placeholder title"
+                   tal:attributes="id string:${subfield_days};
+                         name string:${subfield_days};
+                         value days;"/>
           </div>
 
           <!-- DoB input field -->
-          <div class="form form-inline"
+          <div class="form-group"
                tal:attributes="id string:${fieldName}_dob_controls">
-            <div class="form-row">
-              <div class="form-group">
-                <input type="date"
-                       class="form-control form-control-sm"
-                       tal:attributes="python:widget.attrs();
-                                       id string:${subfield_dob};
-                                       name string:${subfield_dob};
-                                       required python:required and 'required' or None;
-                                       value python: widget.get_date(value) if value else '';"/>
-              </div>
-            </div>
+            <input type="date"
+                   class="form-control form-control-sm"
+                   tal:attributes="python:widget.attrs();
+                         id string:${subfield_dob};
+                         name string:${subfield_dob};
+                         required python:required and 'required' or None;
+                         value python: widget.get_date(value) if value else '';"/>
 
             <!-- Field not visible for when the value is set automatically by
-            others through JS. When a value is set to this field, agedob widget
-            automatically updates the value from the dob_control and selects
-            the proper radiobutton. Note we don't use a hidden field here, cause
-            'onchange' is not triggered for hidden fields -->
+                 others through JS. When a value is set to this field, agedob widget
+                 automatically updates the value from the dob_control and selects
+                 the proper radiobutton. Note we don't use a hidden field here, cause
+                 'onchange' is not triggered for hidden fields -->
             <input type="text" style="display:none;visibility:hidden;"
                    tal:attributes="id string:${fieldName}-dob-fallback;
-                                   name string:${fieldName};
-                                   value string:${value}"/>
+                         name string:${fieldName};
+                         value string:${value}"/>
 
           </div>
         </div>

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -61,12 +61,13 @@
 
           <!-- Age input area -->
           <div class="input-group"
-               style="max-width: 260px;"
+               style="max-width: 260px; flex-wrap: nowrap;"
                tal:attributes="id string:${fieldName}_age_controls">
             <input type="number" min='0' max='150'
                    class="form-control form-control-sm"
                    title="Years"
                    placeholder="Years"
+                   style="padding-right:0px;"
                    i18n:attributes="placeholder title"
                    tal:attributes="id string:${subfield_years};
                          name string:${subfield_years};
@@ -76,6 +77,7 @@
                    class="form-control form-control-sm"
                    title="Months"
                    placeholder="Months"
+                   style="padding-right:0px;"
                    i18n:attributes="placeholder title"
                    tal:attributes="id string:${subfield_months};
                          name string:${subfield_months};
@@ -84,6 +86,7 @@
                    class="form-control form-control-sm"
                    title="Days"
                    placeholder="Days"
+                   style="padding-right:0px;"
                    i18n:attributes="placeholder title"
                    tal:attributes="id string:${subfield_days};
                          name string:${subfield_days};

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -23,7 +23,6 @@
                           session_value python:here.session_restore_value(fieldName, value);
                           cached_value python:request.get(fieldName, session_value);
                           value python:cached_value or value;
-                          value python:field.getEditAccessor(here)() or None;
                           subfield_years string:${fieldName}.years:ignore_empty:record;
                           subfield_months string:${fieldName}.months:ignore_empty:record;
                           subfield_days string:${fieldName}.days:ignore_empty:record;

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/fullnamewidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/fullnamewidget.pt
@@ -44,48 +44,46 @@
 
                           entry_mode python: field.widget.entry_mode or 'parts';
                           fullname_mode python: entry_mode in ['full', 'fullname'];
-                          i18n_domain field/widget/i18n_domain|context/i18n_domain|string:plone;
-                          size python: int(field.widget.size, 15)">
+                          i18n_domain field/widget/i18n_domain|context/i18n_domain|string:plone;">
 
         <div class="field FullnameWidget"
              tal:attributes="data-required python:required and '1' or '0';
-                             data-fieldname string:${fieldName}">
+                    data-fieldname string:${fieldName}">
           <div class="fieldErrorBox" tal:condition="required"></div>
 
-          <div class="form form-inline">
+          <!-- Firstname + lastname input area -->
+          <div class="input-group" tal:condition="not:fullname_mode" style="width:260px;">
+            <input type="text"
+                   title="Firstname"
+                   style="max-width: 50%"
+                   placeholder="Firstname"
+                   class="form-control form-control-sm"
+                   i18n:attributes="title placeholder"
+                   tal:attributes="id string:${subfield_firstname};
+                                   name string:${subfield_firstname};
+                                   value    firstname;
+                                   required required;"/>
+            <input type="text"
+                   title="Lastname"
+                   style="max-width: 50%"
+                   class="form-control form-control-sm"
+                   placeholder="Lastname"
+                   i18n:attributes="title placeholder"
+                   tal:attributes="id string:${subfield_lastname};
+                                   name string:${subfield_lastname};
+                                   value lastname;
+                                   required required;"/>
+          </div>
 
-            <!-- Firstname + lastname input area -->
-            <div class="form-row" tal:condition="not:fullname_mode">
-              <div class="form-group col-md-6">
-                <input type="text"
-                       tal:attributes="id string:${subfield_firstname};
-                                       name string:${subfield_firstname};
-                                       value    firstname;
-                                       required required;
-                                       size     size;
-                                       placeholder python: here.translate(domain=i18n_domain, msgid='Firstname', default='Firstname');"/>
-              </div>
-              <div class="form-group col-md-6">
-                <input type="text"
-                       tal:attributes="id string:${subfield_lastname};
-                                       name string:${subfield_lastname};
-                                       value    lastname;
-                                       required required;
-                                       size     size;
-                                       placeholder python: here.translate(domain=i18n_domain, msgid='Lastname', default='Lastname');"/>
-              </div>
-            </div>
-
-            <!-- Fullname input area -->
-            <div class="form-group" tal:condition="fullname_mode">
-              <input type="text"
-                     tal:attributes="id string:${subfield_firstname};
-                                     name string:${subfield_firstname};
-                                     value    fullname;
-                                     required required;
-                                     size     python:size*2;
-                                     placeholder python: here.translate(domain=i18n_domain, msgid='Fullname', default='Fullname');"/>
-            </div>
+          <!-- Fullname input area -->
+          <div class="form-group" tal:condition="fullname_mode">
+            <input type="text"
+                   placeholder="Fullname"
+                   i18n:attributes="title placeholder"
+                   tal:attributes="id string:${subfield_firstname};
+                                   name string:${subfield_firstname};
+                                   value fullname;
+                                   required required;"/>
           </div>
 
         </div>


### PR DESCRIPTION
## Description

This PR renders the fullname and dob widgets as [input-groups](https://getbootstrap.com/docs/4.6/components/input-group)

<img width="547" alt="CL-BL-21-0245 — SENAITE LIMS 2021-12-13 14-06-37" src="https://user-images.githubusercontent.com/713193/145817939-f65a1ffc-5e25-4e16-981e-96a0312fa534.png">

