### PR TITLE
Remove folderish check in upgrade step

### DIFF
--- a/src/senaite/patient/upgrade/v01_00_000.py
+++ b/src/senaite/patient/upgrade/v01_00_000.py
@@ -95,8 +95,6 @@ def migrate_patient_item_to_container(portal):
     logger.info("Migrate patients to be folderish ...")
     patients = portal.patients
     for patient in patients.objectValues():
-        if api.is_folderish(patient):
-            continue
         pid = patient.getId()
         patients._delOb(pid)
         patient.__class__ = Patient


### PR DESCRIPTION
## Description

Fixture for https://github.com/senaite/senaite.patient/pull/24

This PR removes the `api.is_folderish` check in the upgrade step, because it tests the base class of the object and not the object itself. Therefore, it is always `True` although the object is contentish.