### PR TITLE
Fix cannot create samples with empty Patient ID

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Steps to reproduce
+
+## Current behavior
+
+## Expected behavior
+
+## Screenshot (optional)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Description of the issue/feature this PR addresses
+
+Linked issue: https://github.com/senaite/senaite.patient/issues/
+
+## Current behavior before PR
+
+## Desired behavior after PR is merged
+
+--
+I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
+and [Plone's Python styleguide][2] standards.
+
+[1]: https://www.python.org/dev/peps/pep-0008
+[2]: https://docs.plone.org/develop/styleguide/python.html

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
-- no changes yet
-
+- #27 Fix cannot create samples with empty Patient ID
 
 1.0.0 (2022-01-05)
 ------------------

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -247,10 +247,11 @@ class Patient(Container):
         if self.patient_id == value:
             # noting changed
             return
-        query = {"portal_type": "Patient", "patient_id": value}
-        results = patient_api.patient_search(query)
-        if len(results) > 0:
-            raise ValueError("A patient with that ID already exists!")
+        if value:
+            query = {"portal_type": "Patient", "patient_id": value}
+            results = patient_api.patient_search(query)
+            if len(results) > 0:
+                raise ValueError("A patient with that ID already exists!")
         self.patient_id = value
 
     def get_firstname(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows the creation of Samples without Patient ID being set.

## Current behavior before PR

The following traceback arises on Add Sample form submit when a value for "Patient ID" field is not set:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.analysisrequest.add2, line 72, in decorator
  Module bika.lims.browser.analysisrequest.add2, line 709, in __call__
  Module bika.lims.browser.analysisrequest.add2, line 1642, in ajax_submit
  Module bika.lims.utils.analysisrequest, line 84, in create_analysisrequest
  Module Products.Archetypes.BaseObject, line 685, in processForm
  Module zope.event, line 32, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module senaite.patient, line 56, in wrapper
  Module senaite.patient.subscribers.analysisrequest, line 31, in on_object_created
  Module senaite.patient.subscribers.analysisrequest, line 63, in update_patient
  Module senaite.patient.api, line 121, in update_patient
  Module senaite.patient.content.patient, line 253, in set_patient_id
ValueError: A patient with that ID already exists!
```

## Desired behavior after PR is merged

No traceback arises and both the Sample and Patient are created

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html