### PR TITLE
Remember age/dob selection on context

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,9 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #28 Remember age/dob selection on context
 - #27 Fix cannot create samples with empty Patient ID
+
 
 1.0.0 (2022-01-05)
 ------------------

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -30,7 +30,7 @@
                           years python:current_age.get('years') or '';
                           months python:current_age.get('months') or '';
                           days python:current_age.get('days') or '';
-                          age_selected python:widget.default_age;">
+                          age_selected python:widget.get_age_selected(context);">
 
         <div class="field AgeDoBWidget text-left"
              tal:attributes="data-required python:required and '1' or '0';


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the age/dob selection method

## Current behavior before PR

age/dob selection changed in widget (for all entities)

## Desired behavior after PR is merged

age/dob selection remembered on context

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
