### PR TITLE
Avoid UnknownTimeZoneError when creating patient from Sample

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #29 Avoid UnknownTimeZoneError when creating patient from Sample
 - #28 Remember age/dob selection on context
 - #27 Fix cannot create samples with empty Patient ID
 

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -79,7 +79,8 @@ class PatientFolderView(ListingView):
             ("gender", {
                 "title": _("Gender"), }),
             ("birthdate", {
-                "title": _("Birthdate"), }),
+                "title": _("Birthdate"),
+                "index": "patient_birthdate"}),
         ))
 
         self.review_states = [

--- a/src/senaite/patient/catalog/configure.zcml
+++ b/src/senaite/patient/catalog/configure.zcml
@@ -9,6 +9,7 @@
   <!-- Patient Indexes -->
   <adapter name="patient_mrn" factory=".indexers.patient_mrn" />
   <adapter name="patient_email" factory=".indexers.patient_email" />
+  <adapter name="patient_birthdate" factory=".indexers.patient_birthdate" />
   <adapter name="patient_fullname" factory=".indexers.patient_fullname" />
   <adapter name="patient_searchable_text" factory=".indexers.patient_searchable_text" />
 

--- a/src/senaite/patient/catalog/indexers.py
+++ b/src/senaite/patient/catalog/indexers.py
@@ -46,7 +46,7 @@ def patient_mrn(instance):
 
 @indexer(IPatient)
 def patient_fullname(instance):
-    """Index client fullname
+    """Index fullname
     """
     fullname = instance.get_fullname()
     return fullname
@@ -54,10 +54,18 @@ def patient_fullname(instance):
 
 @indexer(IPatient)
 def patient_email(instance):
-    """Index client email
+    """Index email
     """
     email = instance.get_email()
     return email
+
+
+@indexer(IPatient)
+def patient_birthdate(instance):
+    """Index birthdate
+    """
+    birthdate = instance.get_birthdate()
+    return birthdate
 
 
 @indexer(IPatient)

--- a/src/senaite/patient/catalog/patient_catalog.py
+++ b/src/senaite/patient/catalog/patient_catalog.py
@@ -34,6 +34,7 @@ INDEXES = BASE_INDEXES + [
     ("patient_mrn", "", "FieldIndex"),
     ("patient_email", "", "FieldIndex"),
     ("patient_fullname", "", "FieldIndex"),
+    ("patient_birthdate", "", "DateIndex"),
     ("patient_searchable_text", "", "ZCTextIndex"),
 ]
 

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -330,9 +330,5 @@ class Patient(Container):
     def set_birthdate(self, value):
         """Set birthdate by the field accessor
         """
-        dt = dtime.to_dt(value)
-        if dtime.is_date(dt):
-            # strip off timezone to avoid UnknownTimeZoneError
-            value = dtime.to_dt(dt.strftime("%Y-%m-%d"))
         mutator = self.mutator("birthdate")
         return mutator(self, value)

--- a/src/senaite/patient/upgrade/v01_01_000.py
+++ b/src/senaite/patient/upgrade/v01_01_000.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from senaite.core.api import dtime
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.patient import logger
@@ -62,12 +63,17 @@ def migrate_birthdates(portal):
     logger.info("Migrate patient birthdate timezones ...")
     catalog = api.get_tool(PATIENT_CATALOG)
     results = catalog({"portal_type": "Patient"})
+    timezone = dtime.get_os_timezone()
     for brain in results:
         patient = api.get_object(brain)
         birthdate = patient.birthdate
         if birthdate:
             # clean existing time and timezone
             date = birthdate.strftime("%Y-%m-%d")
+            # append current OS timezone if possible
+            if timezone:
+                date = date + " %s" % timezone
             patient.set_birthdate(date)
+            patient.reindexObject()
 
     logger.info("Migrate patient birthdate timezones [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Please merge https://github.com/senaite/senaite.core/pull/1931 first**

The code of this PR has changed to rely only on the setter from the datetime field.


This PR avoids that the following traceback occurs:

### Traceback:

Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 223, in __call__
  Module senaite.app.listing.ajax, line 109, in handle_subpath
  Module senaite.core.decorators, line 20, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 432, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 313, in get_folderitems
  Module senaite.app.listing.view, line 937, in folderitems
  Module senaite.patient.browser.patientfolder, line 116, in folderitem
  Module bika.lims.api, line 444, in get_url
  Module bika.lims.api, line 268, in is_brain
  Module ZODB.Connection, line 795, in setstate
  Module ZODB.serialize, line 633, in setGhostState
  Module ZODB.serialize, line 626, in getState
  Module pytz, line 307, in _p
  Module pytz.tzinfo, line 539, in unpickler
  Module pytz, line 188, in timezone
UnknownTimeZoneError: (UnknownTimeZoneError('GMT+1',), <function _p at 0x10adda450>, ('GMT+1',))



This happens when a `DateTime` object was converted with `asdatetime` and set to the DX datetime field, which resulted in a static timezone like this:

`datetime.datetime(1980, 2, 25, 0, 0, tzinfo=<StaticTzInfo 'GMT+1'>)`

## Current behavior before PR

After instance restart, the patient object could not be deserialized anymore

## Desired behavior after PR is merged

Valid `datetime` object is set as birthdate

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
