### PR TITLE
Add Patient Identifiers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #30 Add Patient Identifiers
 - #29 Avoid UnknownTimeZoneError when creating patient from Sample
 - #28 Remember age/dob selection on context
 - #27 Fix cannot create samples with empty Patient ID

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -205,3 +205,35 @@ def get_relative_delta(from_date, to_date=None):
         raise TypeError("Type not supported: to_date")
 
     return relativedelta(to_date, from_date)
+
+
+def tuplify_identifiers(identifiers):
+    """Convert identifiers to a list of key/value tuples
+
+    :param identifiers: List of identifier dictionaries
+    :returns: List of tuples
+    """
+    out = []
+    for identifier in identifiers:
+        key = identifier.get("key")
+        value = identifier.get("value")
+        out.append((key, value, ))
+    return out
+
+
+def to_identifier_type_name(identifier_type_key):
+    """Convert an identifier type ID to the human readable name
+
+    :param identifier_type_key: The keyword of the identifier
+    :returns: Indetifiert type name
+    """
+    records = api.get_registry_record("senaite.patient.identifiers")
+
+    name = identifier_type_key
+    for record in records:
+        key = record.get("key")
+        if key != identifier_type_key:
+            continue
+        name = record.get("value")
+
+    return name

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -18,12 +18,25 @@
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import re
+
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
 from plone.app.registry.browser.controlpanel import RegistryEditForm
+from plone.autoform import directives
 from plone.z3cform import layout
+from senaite.core.schema.registry import DataGridRow
+from senaite.core.z3cform.widgets.datagrid import DataGridWidgetFactory
 from senaite.patient import messageFactory as _
+from senaite.patient.api import patient_search
+from senaite.patient.config import IDENTIFIERS
 from zope import schema
 from zope.interface import Interface
+from zope.interface import Invalid
+from zope.interface import invariant
+from zope.interface import provider
+from zope.schema.interfaces import IContextAwareDefaultFactory
+
+
 
 
 class IPatientControlPanel(Interface):

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -70,6 +70,8 @@ class PatientFolderView(ListingView):
             ("patient_id", {
                 "title": _("Patient ID"),
                 "index": "patient_id"}),
+            ("identifiers", {
+                "title": _("Identifiers"), }),
             ("fullname", {
                 "title": _("Fullname"),
                 "index": "patient_fullname"}),
@@ -112,6 +114,34 @@ class PatientFolderView(ListingView):
         """
         super(PatientFolderView, self).before_render()
 
+    def get_identifier_types(self):
+        """Returns a dict of all identifier types
+        """
+        out = dict()
+        types = api.get_registry_record("senaite.patient.identifiers")
+        for t in types:
+            out[t.get("key")] = t.get("value")
+        return out
+
+    def get_identifier_tags(self, identifiers):
+        """Generate a list of identifier tags
+
+        A tag is a string with the following format:
+
+          <title>:<id>
+
+        :returns: list of identifier tags
+        """
+        tags = []
+        types = self.get_identifier_types()
+        for i in identifiers:
+            key = i["key"]
+            value = i["value"]
+            title = types.get(key, key)
+            tag = "{}:{}".format(title, value)
+            tags.append(tag)
+        return tags
+
     def folderitem(self, obj, item, index):
         obj = api.get_object(obj)
         url = api.get_url(obj)
@@ -128,6 +158,11 @@ class PatientFolderView(ListingView):
         if patient_id:
             item["replace"]["patient_id"] = get_link(
                 url, value=patient_id)
+
+        # Patient Identifiers
+        identifiers = obj.getIdentifiers()
+        item["identifiers"] = "<br>".join(
+            self.get_identifier_tags(identifiers))
 
         # Fullname
         fullname = obj.get_fullname().encode("utf8")

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -27,6 +27,8 @@ from bika.lims.utils import get_link
 from senaite.app.listing.view import ListingView
 from senaite.patient import messageFactory as _sp
 from senaite.patient.catalog import PATIENT_CATALOG
+from senaite.patient.api import to_identifier_type_name
+from senaite.patient.api import tuplify_identifiers
 
 
 class PatientFolderView(ListingView):
@@ -114,17 +116,8 @@ class PatientFolderView(ListingView):
         """
         super(PatientFolderView, self).before_render()
 
-    def get_identifier_types(self):
-        """Returns a dict of all identifier types
-        """
-        out = dict()
-        types = api.get_registry_record("senaite.patient.identifiers")
-        for t in types:
-            out[t.get("key")] = t.get("value")
-        return out
-
-    def get_identifier_tags(self, identifiers):
-        """Generate a list of identifier tags
+    def get_identifier_tags(self, identifiers, klass="badge badge-light"):
+        """Generate a list of identifier HTML tags
 
         A tag is a string with the following format:
 
@@ -133,12 +126,12 @@ class PatientFolderView(ListingView):
         :returns: list of identifier tags
         """
         tags = []
-        types = self.get_identifier_types()
-        for i in identifiers:
-            key = i["key"]
-            value = i["value"]
-            title = types.get(key, key)
-            tag = "{}:{}".format(title, value)
+        records = tuplify_identifiers(identifiers)
+        for k, v in records:
+            title = to_identifier_type_name(k)
+            text = "{}: {}".format(title, v)
+            tag = "<span class='{}'>{}</span>".format(
+                klass, text)
             tags.append(tag)
         return tags
 

--- a/src/senaite/patient/catalog/configure.zcml
+++ b/src/senaite/patient/catalog/configure.zcml
@@ -8,6 +8,8 @@
 
   <!-- Patient Indexes -->
   <adapter name="patient_mrn" factory=".indexers.patient_mrn" />
+  <adapter name="patient_identifier_keys" factory=".indexers.patient_identifier_keys" />
+  <adapter name="patient_identifier_values" factory=".indexers.patient_identifier_values" />
   <adapter name="patient_email" factory=".indexers.patient_email" />
   <adapter name="patient_birthdate" factory=".indexers.patient_birthdate" />
   <adapter name="patient_fullname" factory=".indexers.patient_fullname" />

--- a/src/senaite/patient/catalog/indexers.py
+++ b/src/senaite/patient/catalog/indexers.py
@@ -92,6 +92,7 @@ def patient_searchable_text(instance):
         instance.get_mrn(),
         instance.get_fullname(),
         instance.get_gender(),
+        " ".join(instance.get_identifier_ids()),
     ]
     searchable_text_tokens = filter(None, searchable_text_tokens)
     return u" ".join(searchable_text_tokens)

--- a/src/senaite/patient/catalog/indexers.py
+++ b/src/senaite/patient/catalog/indexers.py
@@ -38,6 +38,21 @@ def medical_record_number(instance):
 
 
 @indexer(IPatient)
+def patient_identifier_keys(instance):
+    """Return patient identifier keys
+    """
+    identifiers = instance.getIdentifiers()
+    return map(lambda i: i.get("key"), identifiers)
+
+@indexer(IPatient)
+def patient_identifier_values(instance):
+    """Return patient identifier values
+    """
+    identifiers = instance.getIdentifiers()
+    return map(lambda i: i.get("value"), identifiers)
+
+
+@indexer(IPatient)
 def patient_mrn(instance):
     """Index Medical Record #
     """

--- a/src/senaite/patient/catalog/patient_catalog.py
+++ b/src/senaite/patient/catalog/patient_catalog.py
@@ -32,6 +32,8 @@ INDEXES = BASE_INDEXES + [
     # id, indexed attribute, type
     ("patient_id", "", "FieldIndex"),
     ("patient_mrn", "", "FieldIndex"),
+    ("patient_identifier_keys", "", "KeywordIndex"),
+    ("patient_identifier_values", "", "KeywordIndex"),
     ("patient_email", "", "FieldIndex"),
     ("patient_fullname", "", "FieldIndex"),
     ("patient_birthdate", "", "DateIndex"),

--- a/src/senaite/patient/config.py
+++ b/src/senaite/patient/config.py
@@ -45,8 +45,8 @@ NAME_ENTRY_MODES = (
 
 
 IDENTIFIERS = (
-    ("passport_id", _("Passport ID")),
-    ("national_id", _("National ID")),
-    ("driver_id", _("Driver ID")),
-    ("voter_id", _("Voter ID")),
+    (u"passport_id", _(u"Passport ID")),
+    (u"national_id", _(u"National ID")),
+    (u"driver_id", _(u"Driver ID")),
+    (u"voter_id", _(u"Voter ID")),
 )

--- a/src/senaite/patient/config.py
+++ b/src/senaite/patient/config.py
@@ -42,3 +42,11 @@ NAME_ENTRY_MODES = (
     ("parts", _("First name + last name")),
     ("full", _("Fullname")),
 )
+
+
+IDENTIFIERS = (
+    ("passport_id", _("Passport ID")),
+    ("national_id", _("National ID")),
+    ("driver_id", _("Driver ID")),
+    ("voter_id", _("Voter ID")),
+)

--- a/src/senaite/patient/configure.zcml
+++ b/src/senaite/patient/configure.zcml
@@ -20,6 +20,11 @@
   <!-- Import senaite.patient permissions -->
   <include file="permissions.zcml" />
 
+  <!-- Identifier Vocabulary -->
+  <utility
+      component="senaite.patient.vocabularies.IdentiierVocabularyFactory"
+      name="senaite.patient.vocabularies.identifiers" />
+
   <!-- Gender Vocabulary -->
   <utility
       component="senaite.patient.vocabularies.GenderVocabularyFactory"

--- a/src/senaite/patient/content/__init__.py
+++ b/src/senaite/patient/content/__init__.py
@@ -17,3 +17,17 @@
 #
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
+
+from archetypes.schemaextender.field import ExtensionField
+from Products.Archetypes.public import StringField
+from senaite.core.browser.fields.datetime import DateTimeField
+
+
+class ExtDateTimeField(ExtensionField, DateTimeField):
+    """Extended DateTime Field
+    """
+
+
+class ExtStringField(ExtensionField, StringField):
+    """Extended String Field
+    """

--- a/src/senaite/patient/content/analysisrequest.py
+++ b/src/senaite/patient/content/analysisrequest.py
@@ -22,8 +22,6 @@ from archetypes.schemaextender.interfaces import IBrowserLayerAwareExtender
 from archetypes.schemaextender.interfaces import IOrderableSchemaExtender
 from archetypes.schemaextender.interfaces import ISchemaModifier
 from bika.lims.browser.widgets import SelectionWidget
-from bika.lims.fields import ExtDateTimeField
-from bika.lims.fields import ExtStringField
 from bika.lims.interfaces import IAnalysisRequest
 from Products.Archetypes.Widget import StringWidget
 from Products.CMFCore.permissions import View
@@ -34,6 +32,8 @@ from senaite.patient.browser.widgets import AgeDoBWidget
 from senaite.patient.browser.widgets import FullnameWidget
 from senaite.patient.browser.widgets import TemporaryIdentifierWidget
 from senaite.patient.config import GENDERS
+from senaite.patient.content import ExtDateTimeField
+from senaite.patient.content import ExtStringField
 from senaite.patient.content.fields import FullnameField
 from senaite.patient.content.fields import TemporaryIdentifierField
 from senaite.patient.interfaces import ISenaitePatientLayer

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -19,8 +19,9 @@
 # Some rights reserved, see README and LICENSE.
 
 import six
+
 from AccessControl import ClassSecurityInfo
-from bika.lims.fields import ExtensionField
+from archetypes.schemaextender.field import ExtensionField
 from Products.Archetypes.Field import ObjectField
 from senaite.patient import api as patient_api
 from senaite.patient.browser.widgets import FullnameWidget

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -325,13 +325,24 @@ class Patient(Container):
         accessor = self.accessor("identifiers")
         return accessor(self)
 
+    def get_identifier_items(self):
+        """Returns a list of identifier tuples
+        """
+        identifiers = self.getIdentifiers()
+        return list(map(lambda i: (i["key"], i["value"]), identifiers))
+
+    def get_identifier_ids(self):
+        """Returns a list of identifier IDs
+        """
+        identifiers = self.getIdentifiers()
+        return list(map(lambda i: i["value"], identifiers))
+
     @security.protected(permissions.ModifyPortalContent)
     def setIdentifiers(self, value):
         """Set birthdate by the field accessor
         """
         mutator = self.mutator("identifiers")
         return mutator(self, value)
-
 
     def get_firstname(self):
         firstname = self.firstname

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -50,13 +50,19 @@ class IIdentifiersSchema(Interface):
     """
 
     key = schema.Choice(
-        title=_("Identifier key"),
+        title=_("Type"),
+        description=_(
+            u"The type of identifier that holds the ID"
+        ),
         source="senaite.patient.vocabularies.identifiers",
         required=True,
     )
 
     value = schema.TextLine(
-        title=_(u"Identifier value"),
+        title=_(u"ID"),
+        description=_(
+            u"The identification number of the selected identifier"
+        ),
         required=True,
     )
 
@@ -311,6 +317,21 @@ class Patient(Container):
             if len(results) > 0:
                 raise ValueError("A patient with that ID already exists!")
         self.patient_id = value
+
+    @security.protected(permissions.View)
+    def getIdentifiers(self):
+        """Returns the birthday with the field accessor
+        """
+        accessor = self.accessor("identifiers")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setIdentifiers(self, value):
+        """Set birthdate by the field accessor
+        """
+        mutator = self.mutator("identifiers")
+        return mutator(self, value)
+
 
     def get_firstname(self):
         firstname = self.firstname

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -28,8 +28,10 @@ from plone.dexterity.content import Container
 from plone.supermodel import model
 from plone.supermodel.directives import fieldset
 from Products.CMFCore import permissions
-from senaite.core.api import dtime
 from senaite.core.schema import DatetimeField
+from senaite.core.schema.fields import DataGridField
+from senaite.core.schema.fields import DataGridRow
+from senaite.core.z3cform.widgets.datagrid import DataGridWidgetFactory
 from senaite.core.z3cform.widgets.datetimewidget import DatetimeWidget
 from senaite.patient import api as patient_api
 from senaite.patient import messageFactory as _
@@ -37,9 +39,26 @@ from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.config import GENDERS
 from senaite.patient.interfaces import IPatient
 from zope import schema
+from zope.interface import Interface
 from zope.interface import Invalid
 from zope.interface import implementer
 from zope.interface import invariant
+
+
+class IIdentifiersSchema(Interface):
+    """Schema definition for identifier records field
+    """
+
+    key = schema.Choice(
+        title=_("Identifier key"),
+        source="senaite.patient.vocabularies.identifiers",
+        required=True,
+    )
+
+    value = schema.TextLine(
+        title=_(u"Identifier value"),
+        required=True,
+    )
 
 
 class IPatientSchema(model.Schema):
@@ -82,6 +101,23 @@ class IPatientSchema(model.Schema):
         title=_(u"label_patient_id", default=u"ID"),
         description=_(u"Unique Patient ID"),
         required=False,
+    )
+
+    directives.widget(
+        "identifiers",
+        DataGridWidgetFactory,
+        auto_append=True)
+    identifiers = DataGridField(
+        title=_(u"Patient Identifiers"),
+        description=_(
+            u"Define one or more identifers for this patient"
+        ),
+        value_type=DataGridRow(
+            title=u"Identifier",
+            schema=IIdentifiersSchema),
+        required=False,
+        missing_value=[],
+        default=[],
     )
 
     firstname = schema.TextLine(

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -22,6 +22,8 @@ Needed Imports:
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_PASSWORD
     >>> from bika.lims.api.security import get_roles_for_permission
+    >>> from senaite.patient.api import tuplify_identifiers
+    >>> from senaite.patient.api import to_identifier_type_name
 
 Functional Helpers:
 
@@ -136,3 +138,34 @@ Changing the patient data won't affect the values in a sample:
 
     >>> sample.getPatientFullName()
     'Clark Kent'
+
+
+Patient Identifiers
+...................
+
+Identifiers allow to add multiple IDs for a patient. Each identifier consists
+from a type, e.g. *Drivers License* and the actal ID, e.g. *123456789*.
+
+The types of identifiers can be configured in the patient controlpanel, which
+stores the values in the registry:
+
+    >>> reg_key = "senaite.patient.identifiers"
+    >>> record = api.get_registry_record(reg_key)
+    >>> tuplify_identifiers(record)
+    [(u'passport_id', u'Passport ID'), (u'national_id', u'National ID'), (u'driver_id', u'Driver ID'), (u'voter_id', u'Voter ID')]
+
+Let's add a passport ID for our patient:
+
+    >>> identifiers = [{"key": "passport_id", "value": "123456789"}]
+    >>> patient.setIdentifiers(identifiers)
+    >>> record = patient.getIdentifiers()
+    >>> tuplify_identifiers(record)
+    [('passport_id', '123456789')]
+
+Converting the identifier keyword into the title:
+
+    >>> to_identifier_type_name("passport_id")
+    u'Passport ID'
+
+    >>> to_identifier_type_name("driver_id")
+    u'Driver ID'

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -27,11 +27,6 @@ Needed Imports:
 
 Functional Helpers:
 
-    >>> def start_server():
-    ...     from Testing.ZopeTestCase.utils import startZServer
-    ...     ip, port = startZServer()
-    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
-
     >>> def timestamp(format="%Y-%m-%d"):
     ...     return DateTime().strftime(format)
 

--- a/src/senaite/patient/tests/doctests/PatientWorkflow.rst
+++ b/src/senaite/patient/tests/doctests/PatientWorkflow.rst
@@ -25,11 +25,6 @@ Needed Imports:
 
 Functional Helpers:
 
-    >>> def start_server():
-    ...     from Testing.ZopeTestCase.utils import startZServer
-    ...     ip, port = startZServer()
-    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
-
     >>> def timestamp(format="%Y-%m-%d"):
     ...     return DateTime().strftime(format)
 

--- a/src/senaite/patient/upgrade/v01_01_000.py
+++ b/src/senaite/patient/upgrade/v01_01_000.py
@@ -28,6 +28,7 @@ from senaite.patient.config import PRODUCT_NAME
 from senaite.patient.setuphandlers import setup_catalogs
 
 version = "1.1.0"
+profile = "profile-{0}:default".format(PRODUCT_NAME)
 
 
 @upgradestep(PRODUCT_NAME, version)
@@ -46,6 +47,7 @@ def upgrade(tool):
                                                    version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    setup.runImportStepFromProfile(profile, "controlpanel")
 
     # add dateindex for birthdates
     setup_catalogs(portal)

--- a/src/senaite/patient/upgrade/v01_01_000.py
+++ b/src/senaite/patient/upgrade/v01_01_000.py
@@ -48,6 +48,7 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF BELOW --------
     setup.runImportStepFromProfile(profile, "controlpanel")
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
 
     # add dateindex for birthdates
     setup_catalogs(portal)

--- a/src/senaite/patient/vocabularies.py
+++ b/src/senaite/patient/vocabularies.py
@@ -20,11 +20,31 @@
 
 from senaite.core.locales import COUNTRIES
 from senaite.patient.config import GENDERS
+from senaite.patient.config import IDENTIFIERS
 from senaite.patient.config import NAME_ENTRY_MODES
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
+
+
+@implementer(IVocabularyFactory)
+class IdentifierVocabulary(object):
+
+    def __call__(self, context):
+
+        items = []
+        for identifier in IDENTIFIERS:
+            value = identifier[0]
+            token = identifier[0]
+            title = identifier[1]
+            # value, token, title
+            term = SimpleTerm(value, token, title)
+            items.append(term)
+        return SimpleVocabulary(sorted(items, key=lambda t: t.title))
+
+
+IdentiierVocabularyFactory = IdentifierVocabulary()
 
 
 @implementer(IVocabularyFactory)

--- a/src/senaite/patient/vocabularies.py
+++ b/src/senaite/patient/vocabularies.py
@@ -26,6 +26,7 @@ from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
+from bika.lims import api
 
 
 @implementer(IVocabularyFactory)
@@ -33,13 +34,15 @@ class IdentifierVocabulary(object):
 
     def __call__(self, context):
 
+        identifiers = api.get_registry_record("senaite.patient.identifiers")
+
         items = []
-        for identifier in IDENTIFIERS:
-            value = identifier[0]
-            token = identifier[0]
-            title = identifier[1]
+        for identifier in identifiers:
+            # note: the key will get the submitted value
+            keyword = identifier.get("key")
+            title = identifier.get("value")
             # value, token, title
-            term = SimpleTerm(value, token, title)
+            term = SimpleTerm(keyword, keyword, title)
             items.append(term)
         return SimpleVocabulary(sorted(items, key=lambda t: t.title))
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds configurable identifiers for patients.

Identifiers can be e.g. Drivers License, Voter ID, Passport ID etc.
and can be configured in the Patient setup:

<img width="908" alt="SENAITE LIMS 2022-02-18 1 PM-45-38" src="https://user-images.githubusercontent.com/713193/154685420-81148490-5ff4-42d4-bf29-a1b868ed0f5b.png">

Multiple identifiers can then be added to a patient:

<img width="694" alt="Ramon Bartl — SENAITE LIMS 2022-02-18 1 PM-48-22" src="https://user-images.githubusercontent.com/713193/154685782-cc143e51-79b3-432b-beb6-6840236cc54c.png">

Note: Identifiers that are in use can not be deleted! Only the title can be changed afterwards.

## Current behavior before PR

No identifiers for patients available

## Desired behavior after PR is merged

Identifiers can be configured for patients
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
