### PR TITLE
Allow patient to receive result reports

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #30 Add Patient Identifiers
 - #29 Avoid UnknownTimeZoneError when creating patient from Sample
 - #28 Remember age/dob selection on context
 - #27 Fix cannot create samples with empty Patient ID

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #31 Allow patient to receive result reports
 - #30 Add Patient Identifiers
 - #29 Avoid UnknownTimeZoneError when creating patient from Sample
 - #28 Remember age/dob selection on context

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -165,7 +165,7 @@ class PatientFolderView(ListingView):
                 url, value=fullname)
 
         # Email
-        email = obj.get_email()
+        email = obj.getEmail()
         item["email"] = email
         if email:
             item["replace"]["email"] = get_email_link(

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -77,6 +77,9 @@ class PatientFolderView(ListingView):
             ("fullname", {
                 "title": _("Fullname"),
                 "index": "patient_fullname"}),
+            ("email_report", {
+                "title": _("Email Report"),
+                "index": "patient_email_report"}),
             ("email", {
                 "title": _("Email"),
                 "index": "patient_email"}),
@@ -170,6 +173,10 @@ class PatientFolderView(ListingView):
         if email:
             item["replace"]["email"] = get_email_link(
                 email, value=email)
+
+        # Email Report
+        email_report = obj.getEmailReport()
+        item["email_report"] = _("Yes") if email_report else _("No")
 
         # Gender
         item["gender"] = obj.get_gender()

--- a/src/senaite/patient/catalog/configure.zcml
+++ b/src/senaite/patient/catalog/configure.zcml
@@ -11,6 +11,7 @@
   <adapter name="patient_identifier_keys" factory=".indexers.patient_identifier_keys" />
   <adapter name="patient_identifier_values" factory=".indexers.patient_identifier_values" />
   <adapter name="patient_email" factory=".indexers.patient_email" />
+  <adapter name="patient_email_report" factory=".indexers.patient_email_report" />
   <adapter name="patient_birthdate" factory=".indexers.patient_birthdate" />
   <adapter name="patient_fullname" factory=".indexers.patient_fullname" />
   <adapter name="patient_searchable_text" factory=".indexers.patient_searchable_text" />

--- a/src/senaite/patient/catalog/indexers.py
+++ b/src/senaite/patient/catalog/indexers.py
@@ -71,7 +71,7 @@ def patient_fullname(instance):
 def patient_email(instance):
     """Index email
     """
-    email = instance.get_email()
+    email = instance.getEmail()
     return email
 
 
@@ -88,7 +88,7 @@ def patient_searchable_text(instance):
     """Index for searchable text queries
     """
     searchable_text_tokens = [
-        instance.get_email(),
+        instance.getEmail(),
         instance.get_mrn(),
         instance.get_fullname(),
         instance.get_gender(),

--- a/src/senaite/patient/catalog/indexers.py
+++ b/src/senaite/patient/catalog/indexers.py
@@ -76,6 +76,14 @@ def patient_email(instance):
 
 
 @indexer(IPatient)
+def patient_email_report(instance):
+    """Index email
+    """
+    email_report = instance.getEmailReport()
+    return email_report
+
+
+@indexer(IPatient)
 def patient_birthdate(instance):
     """Index birthdate
     """

--- a/src/senaite/patient/catalog/patient_catalog.py
+++ b/src/senaite/patient/catalog/patient_catalog.py
@@ -35,6 +35,7 @@ INDEXES = BASE_INDEXES + [
     ("patient_identifier_keys", "", "KeywordIndex"),
     ("patient_identifier_values", "", "KeywordIndex"),
     ("patient_email", "", "FieldIndex"),
+    ("patient_email_report", "", "BooleanIndex"),
     ("patient_fullname", "", "FieldIndex"),
     ("patient_birthdate", "", "DateIndex"),
     ("patient_searchable_text", "", "ZCTextIndex"),

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -410,11 +410,6 @@ class Patient(Container):
         return " ".join(full).strip()
 
     @security.protected(permissions.View)
-    def get_email(self):
-        # BBB: Remove
-        return self.getEmail()
-
-    @security.protected(permissions.View)
     def getEmail(self):
         """Returns the email with the field accessor
         """

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -368,6 +368,20 @@ class Patient(Container):
         mutator = self.mutator("identifiers")
         return mutator(self, value)
 
+    @security.protected(permissions.View)
+    def getEmailReport(self):
+        """Returns the email report option
+        """
+        accessor = self.accessor("email_report")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setEmailReport(self, value):
+        """Set the email report option
+        """
+        mutator = self.mutator("email_report")
+        return mutator(self, value)
+
     def get_firstname(self):
         firstname = self.firstname
         if not firstname:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**☝️ NOTE** Please merge https://github.com/senaite/senaite.patient/pull/30 first!

This PR allows to include the patient email into the sample CC emails to receive result reports:

<img width="394" alt="Ramon Bartl — SENAITE LIMS 2022-02-18 4 PM-43-24" src="https://user-images.githubusercontent.com/713193/154714660-59aa78be-5880-446b-8bba-08015489ee19.png">

## Current behavior before PR

Patient email not included in result reports

## Desired behavior after PR is merged

Patient email automatically included in sample CC emails when the email report option is set for a patient

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
