### PR TITLE
Refactor getter setters

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -42,13 +42,13 @@ sources = sources
 auto-checkout = *
 
 [sources]
-senaite.core = git git://github.com/senaite/senaite.core.git pushurl=git@github.com:senaite/senaite.core.git branch=2.x
-senaite.app.listing = git git://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
-senaite.app.spotlight = git git://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
-senaite.app.supermodel = git git://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
-senaite.impress = git git://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
-senaite.jsonapi = git git://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
-senaite.lims = git git://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
+senaite.core = git https://github.com/senaite/senaite.core.git pushurl=git@github.com:senaite/senaite.core.git branch=2.x
+senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
+senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
+senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
+senaite.impress = git https://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
+senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
+senaite.lims = git https://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -117,12 +117,12 @@ def update_patient(patient, **values):
     """Create a new patient
     """
     # set values explicitly
-    patient.set_mrn(values.get("mrn", api.get_id(patient)))
-    patient.set_patient_id(values.get("patient_id", ""))
-    patient.set_firstname(values.get("firstname", ""))
-    patient.set_lastname(values.get("lastname", ""))
-    patient.set_gender(values.get("gender", ""))
-    patient.set_birthdate(values.get("birthdate"))
+    patient.setMRN(values.get("mrn", api.get_id(patient)))
+    patient.setPatientID(values.get("patient_id", ""))
+    patient.setFirstname(values.get("firstname", ""))
+    patient.setLastname(values.get("lastname", ""))
+    patient.setGender(values.get("gender", ""))
+    patient.setBirthdate(values.get("birthdate"))
     patient.address = values.get("address")
     # reindex the new values
     patient.reindexObject()

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -143,17 +143,20 @@ class PatientFolderView(ListingView):
         url = api.get_url(obj)
 
         # MRN
-        mrn = obj.get_mrn().encode("utf8")
-        item["mrn"] = mrn
-        item["replace"]["mrn"] = get_link(
-            url, value=mrn)
+        mrn = obj.getMRN() or obj.getId()
+        if mrn:
+            mrn = api.safe_unicode(mrn).encode("utf8")
+            item["mrn"] = mrn
+            item["replace"]["mrn"] = get_link(
+                url, value=mrn)
 
         # Patient ID
-        patient_id = obj.get_patient_id().encode("utf8")
-        item["patient_id"] = patient_id
-        if patient_id:
+        pid = obj.getPatientID()
+        if pid:
+            pid = api.safe_unicode(pid).encode("utf8")
+            item["patient_id"] = pid
             item["replace"]["patient_id"] = get_link(
-                url, value=patient_id)
+                url, value=pid)
 
         # Patient Identifiers
         identifiers = obj.getIdentifiers()
@@ -161,16 +164,17 @@ class PatientFolderView(ListingView):
             self.get_identifier_tags(identifiers))
 
         # Fullname
-        fullname = obj.get_fullname().encode("utf8")
-        item["fullname"] = fullname
+        fullname = obj.getFullname()
         if fullname:
+            fullname = api.safe_unicode(fullname).encode("utf8")
+            item["fullname"] = fullname
             item["replace"]["fullname"] = get_link(
                 url, value=fullname)
 
         # Email
         email = obj.getEmail()
-        item["email"] = email
         if email:
+            item["email"] = email
             item["replace"]["email"] = get_email_link(
                 email, value=email)
 
@@ -179,10 +183,11 @@ class PatientFolderView(ListingView):
         item["email_report"] = _("Yes") if email_report else _("No")
 
         # Gender
-        item["gender"] = obj.get_gender()
+        item["gender"] = obj.getGender()
 
         # Birthdate
-        birthdate = obj.get_birthdate()
-        item["birthdate"] = self.ulocalized_time(birthdate, long_format=0)
+        birthdate = obj.getBirthdate()
+        if birthdate:
+            item["birthdate"] = self.ulocalized_time(birthdate, long_format=0)
 
         return item

--- a/src/senaite/patient/catalog/indexers.py
+++ b/src/senaite/patient/catalog/indexers.py
@@ -56,14 +56,14 @@ def patient_identifier_values(instance):
 def patient_mrn(instance):
     """Index Medical Record #
     """
-    return instance.get_mrn()
+    return instance.getMRN()
 
 
 @indexer(IPatient)
 def patient_fullname(instance):
     """Index fullname
     """
-    fullname = instance.get_fullname()
+    fullname = instance.getFullname()
     return fullname
 
 
@@ -87,7 +87,7 @@ def patient_email_report(instance):
 def patient_birthdate(instance):
     """Index birthdate
     """
-    birthdate = instance.get_birthdate()
+    birthdate = instance.getBirthdate()
     return birthdate
 
 
@@ -97,9 +97,9 @@ def patient_searchable_text(instance):
     """
     searchable_text_tokens = [
         instance.getEmail(),
-        instance.get_mrn(),
-        instance.get_fullname(),
-        instance.get_gender(),
+        instance.getMRN(),
+        instance.getFullname(),
+        instance.getGender(),
         " ".join(instance.get_identifier_ids()),
     ]
     searchable_text_tokens = filter(None, searchable_text_tokens)

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -315,35 +315,48 @@ class Patient(Container):
             return None
         return schema[fieldname].set
 
+    @security.protected(permissions.View)
     def Title(self):
-        fullname = self.get_fullname()
+        fullname = self.getFullname()
         return fullname.encode("utf8")
 
-    def get_mrn(self):
-        return self.mrn
+    @security.protected(permissions.View)
+    def getMRN(self):
+        """Returns the MRN with the field accessor
+        """
+        accessor = self.accessor("mrn")
+        value = accessor(self)
+        if not value:
+            return u""
+        return value
 
-    def set_mrn(self, value):
+    @security.protected(permissions.ModifyPortalContent)
+    def setMRN(self, value):
+        """Set MRN by the field accessor
+        """
         value = value.strip()
-        if self.mrn == value:
-            # noting changed
-            return
         if patient_api.get_patient_by_mrn(
                 value, full_object=False, include_inactive=True):
             raise ValueError("A patient with that MRN already exists!")
-        self.mrn = value
+        mutator = self.mutator("mrn")
+        return mutator(self, value)
 
-    def get_patient_id(self):
-        patient_id = self.patient_id
-        if not patient_id:
+    @security.protected(permissions.View)
+    def getPatientID(self):
+        """Returns the Patient ID with the field accessor
+        """
+        accessor = self.accessor("patient_id")
+        value = accessor(self)
+        if not value:
             return u""
-        return self.patient_id
+        return value
 
-    def set_patient_id(self, value):
-        value = value.strip()
-        if self.patient_id == value:
-            # noting changed
-            return
+    @security.protected(permissions.ModifyPortalContent)
+    def setPatientID(self, value):
+        """Set Patient ID by the field accessor
+        """
         if value:
+            value = value.strip()
             query = {"portal_type": "Patient", "patient_id": value}
             results = patient_api.patient_search(query)
             if len(results) > 0:
@@ -390,29 +403,34 @@ class Patient(Container):
         mutator = self.mutator("email_report")
         return mutator(self, value)
 
-    def get_firstname(self):
+    @security.protected(permissions.View)
+    def getFirstname(self):
         firstname = self.firstname
         if not firstname:
             return u""
         return firstname.strip()
 
-    def set_firstname(self, value):
+    @security.protected(permissions.ModifyPortalContent)
+    def setFirstname(self, value):
         if not isinstance(value, string_types):
             self.firstname = ""
         self.firstname = api.safe_unicode(value)
 
-    def get_lastname(self):
+    @security.protected(permissions.View)
+    def getLastname(self):
         lastname = self.lastname
         if not lastname:
             return u""
         return lastname.strip()
 
-    def set_lastname(self, value):
+    @security.protected(permissions.ModifyPortalContent)
+    def setLastname(self, value):
         if not isinstance(value, string_types):
             self.lastname = ""
         self.lastname = api.safe_unicode(value)
 
-    def get_fullname(self):
+    @security.protected(permissions.View)
+    def getFullname(self):
         # Create the fullname from firstname + lastname
         full = filter(None, [self.firstname, self.lastname])
         return " ".join(full).strip()
@@ -434,25 +452,34 @@ class Patient(Container):
         mutator = self.mutator("email")
         return mutator(self, value)
 
-    def get_gender(self):
+    @security.protected(permissions.View)
+    def getGender(self):
+        """Returns the gender with the field accessor
+        """
+        accessor = self.accessor("gender")
         genders = dict(GENDERS)
-        return genders.get(self.gender)
+        value = accessor(self)
+        return genders.get(value)
 
-    def set_gender(self, value):
+    @security.protected(permissions.ModifyPortalContent)
+    def setGender(self, value):
+        """Set birthdate by the field accessor
+        """
         for k, v in GENDERS:
             if value == v:
                 value = k
-        self.gender = value
+        mutator = self.mutator("gender")
+        return mutator(self, value)
 
     @security.protected(permissions.View)
-    def get_birthdate(self):
+    def getBirthdate(self):
         """Returns the birthday with the field accessor
         """
         accessor = self.accessor("birthdate")
         return accessor(self)
 
     @security.protected(permissions.ModifyPortalContent)
-    def set_birthdate(self, value):
+    def setBirthdate(self, value):
         """Set birthdate by the field accessor
         """
         mutator = self.mutator("birthdate")

--- a/src/senaite/patient/subscribers/patient.py
+++ b/src/senaite/patient/subscribers/patient.py
@@ -28,13 +28,13 @@ def on_before_transition(instance, event):
     # we only care when reactivating the patient
     if event.new_state.getId() != "active":
         return
-    mrn = instance.get_mrn()
+    mrn = instance.getMRN()
     patient = patient_api.get_patient_by_mrn(mrn, full_object=False)
     if not patient:
         return True
     # set UID as new MRN #
     uid = api.get_uid(instance)
-    instance.set_mrn(api.get_uid(instance))
+    instance.setMRN(api.get_uid(instance))
     # Add warning message
     message = "Duplicate MRN # '{}' was changed to '{}'".format(mrn, uid)
     instance.plone_utils.addPortalMessage(message, "warning")

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -123,12 +123,12 @@ When a new patient MRN was referenced in a sample, a new patient is created:
 
 Changing the patient data won't affect the values in a sample:
 
-    >>> patient.get_fullname()
+    >>> patient.getFullname()
     u'Clark Kent'
 
-    >>> patient.set_firstname("Superman")
+    >>> patient.setFirstname("Superman")
 
-    >>> patient.get_fullname()
+    >>> patient.getFullname()
     u'Superman'
 
     >>> sample.getPatientFullName()

--- a/src/senaite/patient/upgrade/v01_00_000.py
+++ b/src/senaite/patient/upgrade/v01_00_000.py
@@ -151,7 +151,7 @@ def fix_patients_fullname(portal):
         raw = patient.__dict__
         firstname = raw.get("fullname", None)
         if firstname:
-            patient.set_firstname(firstname)
+            patient.setFirstname(firstname)
             del(patient.__dict__["fullname"])
             patient.reindexObject()
 

--- a/src/senaite/patient/upgrade/v01_01_000.py
+++ b/src/senaite/patient/upgrade/v01_01_000.py
@@ -76,7 +76,7 @@ def migrate_birthdates(portal):
             # append current OS timezone if possible
             if timezone:
                 date = date + " %s" % timezone
-            patient.set_birthdate(date)
+            patient.setBirthdate(date)
             patient.reindexObject()
 
     logger.info("Migrate patient birthdate timezones [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR refactors the getters/setters to use the schema accessors/mutators.

## Current behavior before PR

Patient setters/getters wrote values directly on the attribute

## Desired behavior after PR is merged

Patient setters/getters use the schema accessors/mutators


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
