### PR TITLE
Do not display Patient root folder to users other than lab contacts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #36 Do not display Patient root folder to users other than lab contact
 - #35 Integrate new DX address field for patients
 - #34 Fix UnicodeDecodeError when storing Patients with special characters
 - #31 Allow patient to receive result reports

--- a/src/senaite/patient/profiles/default/workflows.xml
+++ b/src/senaite/patient/profiles/default/workflows.xml
@@ -1,12 +1,20 @@
 <?xml version="1.0"?>
 <object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+  <!-- senaite.patient-specific workflows -->
+  <object name="senaite_patient_folder_workflow" meta_type="Workflow"/>
   <object name="senaite_patient_workflow" meta_type="Workflow"/>
+
   <bindings>
+
     <type type_id="PatientFolder">
-      <bound-workflow workflow_id="senaite_one_state_workflow"/>
+      <bound-workflow workflow_id="senaite_patient_folder_workflow"/>
     </type>
+
     <type type_id="Patient">
       <bound-workflow workflow_id="senaite_patient_workflow"/>
     </type>
+
   </bindings>
+
 </object>

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<dc-workflow xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+             workflow_id="senaite_patient_folder_workflow"
+             title="Workflow for patient root folders"
+             description="A one-state (active) workflow for patient root folder"
+             state_variable="review_state"
+             initial_state="active"
+             manager_bypass="False"
+             i18n:domain="senaite.patient">
+
+  <!-- PLONE permissions -->
+  <permission>Access contents information</permission>
+  <permission>Delete objects</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify portal content</permission>
+  <permission>View</permission>
+
+  <!-- State: active -->
+  <state state_id="active" title="Active" i18n:attributes="title">
+    <exit-transition transition_id="" />
+    <permission-map name="Access contents information" acquired="False">
+      <!-- All except Anonymous and Client -->
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <!-- Plone roles -->
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False" />
+    <permission-map name="List folder contents" acquired="False">
+      <!-- All except Anonymous and Client -->
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <!-- Plone roles -->
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <!-- All except Anonymous and Client -->
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <!-- Plone roles -->
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+  </state>
+
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+      <expression>transition/getId|nothing</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+    <description>The ID of the user who performed the last transition</description>
+    <default>
+      <expression>user/getId</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+      <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+      <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+      <expression>state_change/getDateTime</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+</dc-workflow>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request updatest the workflow bound to "Patients" root folder so it is only displayed to users from laboratory

Linked issue: https://github.com/senaite/senaite.patient/issues/

## Current behavior before PR

Client contacts can see Patients root folder link

## Desired behavior after PR is merged

The Patients folder link is only visible to laboratory contacts

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
