### PR TITLE
Allow client users to create samples and patients

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #37 Allow client users to create samples and patients
 - #36 Do not display Patient root folder to users other than lab contact
 - #35 Integrate new DX address field for patients
 - #34 Fix UnicodeDecodeError when storing Patients with special characters

--- a/src/senaite/patient/profiles/default/rolemap.xml
+++ b/src/senaite/patient/profiles/default/rolemap.xml
@@ -24,28 +24,35 @@
       <role name="Manager"/>
     </permission>
 
-    <!-- Field permissions -->
+    <!-- Permissions for Sample fields
+    User who creates the object (Owner) has all rights granted by default
+    -->
     <permission name="senaite.patient: Field: Edit MRN" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
     <permission name="senaite.patient: Field: Edit Fullname" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
     <permission name="senaite.patient: Field: Edit Date of Birth" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
     <permission name="senaite.patient: Field: Edit Gender" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
     <permission name="senaite.patient: Field: Edit Address" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
@@ -9,6 +9,7 @@
              i18n:domain="senaite.patient">
 
   <!-- PLONE permissions -->
+  <permission>Add portal content</permission>
   <permission>Access contents information</permission>
   <permission>Delete objects</permission>
   <permission>List folder contents</permission>
@@ -29,6 +30,7 @@
       <permission-role>SamplingCoordinator</permission-role>
       <!-- Plone roles -->
       <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="Delete objects" acquired="False" />
@@ -45,13 +47,23 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Client</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <!-- Plone roles -->
+      <permission-role>Manager</permission-role>
+    </permission-map>
     <permission-map name="Modify portal content" acquired="False">
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
+      <!-- Plone roles -->
       <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
     </permission-map>
     <permission-map name="View" acquired="False">
       <!-- All except Anonymous and Client -->
+      <permission-role>Client</permission-role>
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
@@ -61,6 +73,7 @@
       <permission-role>SamplingCoordinator</permission-role>
       <!-- Plone roles -->
       <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
   </state>

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
@@ -62,7 +62,7 @@
       <permission-role>Owner</permission-role>
     </permission-map>
     <permission-map name="View" acquired="False">
-      <!-- All except Anonymous and Client -->
+      <!-- All except Anonymous -->
       <permission-role>Client</permission-role>
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_workflow/definition.xml
@@ -44,7 +44,21 @@
     <permission-map name="Delete objects" acquired="True" />
     <permission-map name="List folder contents" acquired="True" />
     <permission-map name="Modify portal content" acquired="True" />
-    <permission-map name="View" acquired="True" />
+
+    <permission-map name="View" acquired="False">
+      <!-- All except Anonymous and Client -->
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <!-- Plone roles -->
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
     <!-- senaite.patient permissions -->
     <permission-map name="senaite.patient: Field: Edit MRN" acquired="True" />
     <permission-map name="senaite.patient: Field: Edit ID" acquired="True" />


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that client users can create patients and samples.

## Current behavior before PR

An error arises when client users try to create a Sample with patient information. The sample without patient information is created in the background without the user being noticed, but without information regarding patient.

## Desired behavior after PR is merged

- The sample is created properly, with information about the patient
- Client user can navigate to Patients and see the Patients he/she created and edit them
- Client user cannot see Patients created by other users

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
