### PR TITLE
Allow to share patients across clients

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #37 Allow client users to create samples and patients
 - #36 Do not display Patient root folder to users other than lab contact
 - #35 Integrate new DX address field for patients
 - #34 Fix UnicodeDecodeError when storing Patients with special characters

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -112,6 +112,13 @@ class IPatientControlPanel(Interface):
         default=False,
     )
 
+    share_patients = schema.Bool(
+        title=_(u"Share patient on sample creation"),
+        description=_(u"If selected, patients created or referred on sample "
+                      u"creation will automatically be shared across users "
+                      u"from same client the sample belongs to")
+    )
+
     @invariant
     def validate_identifiers(data):
         """Checks if the keyword is unique and valid

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -19,17 +19,16 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
+
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.utils import get_email_link
 from bika.lims.utils import get_link
-from bika.lims.utils import get_link_for
 from senaite.app.listing.view import ListingView
-from senaite.core.behaviors import IClientShareableBehavior
 from senaite.patient import messageFactory as _sp
+from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.api import to_identifier_type_name
 from senaite.patient.api import tuplify_identifiers
-from senaite.patient.catalog import PATIENT_CATALOG
 
 
 class PatientFolderView(ListingView):
@@ -89,9 +88,6 @@ class PatientFolderView(ListingView):
             ("birthdate", {
                 "title": _("Birthdate"),
                 "index": "patient_birthdate"}),
-            ("shared_with", {
-                "title": _("Shared with"),
-            })
         ))
 
         self.review_states = [
@@ -197,11 +193,5 @@ class PatientFolderView(ListingView):
         birthdate = obj.getBirthdate()
         if birthdate:
             item["birthdate"] = self.ulocalized_time(birthdate, long_format=0)
-
-        # Shared with
-        behavior = IClientShareableBehavior(obj)
-        clients = filter(None, behavior.getClients())
-        clients = [get_link_for(client) for client in clients]
-        item["replace"]["shared_with"] = ", ".join(clients)
 
         return item

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -19,16 +19,17 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
-
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.utils import get_email_link
 from bika.lims.utils import get_link
+from bika.lims.utils import get_link_for
 from senaite.app.listing.view import ListingView
+from senaite.core.behaviors import IClientShareableBehavior
 from senaite.patient import messageFactory as _sp
-from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.api import to_identifier_type_name
 from senaite.patient.api import tuplify_identifiers
+from senaite.patient.catalog import PATIENT_CATALOG
 
 
 class PatientFolderView(ListingView):
@@ -88,6 +89,9 @@ class PatientFolderView(ListingView):
             ("birthdate", {
                 "title": _("Birthdate"),
                 "index": "patient_birthdate"}),
+            ("shared_with", {
+                "title": _("Shared with"),
+            })
         ))
 
         self.review_states = [
@@ -193,5 +197,11 @@ class PatientFolderView(ListingView):
         birthdate = obj.getBirthdate()
         if birthdate:
             item["birthdate"] = self.ulocalized_time(birthdate, long_format=0)
+
+        # Shared with
+        behavior = IClientShareableBehavior(obj)
+        clients = filter(None, behavior.getClients())
+        clients = [get_link_for(client) for client in clients]
+        item["replace"]["shared_with"] = ", ".join(clients)
 
         return item

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -18,8 +18,6 @@
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from six import string_types
-
 from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims.api.mail import is_valid_email_address
@@ -28,6 +26,7 @@ from plone.dexterity.content import Container
 from plone.supermodel import model
 from plone.supermodel.directives import fieldset
 from Products.CMFCore import permissions
+from senaite.core.behaviors import IClientShareable
 from senaite.core.schema import AddressField
 from senaite.core.schema import DatetimeField
 from senaite.core.schema.addressfield import OTHER_ADDRESS
@@ -42,10 +41,11 @@ from senaite.patient import messageFactory as _
 from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.config import GENDERS
 from senaite.patient.interfaces import IPatient
+from six import string_types
 from zope import schema
+from zope.interface import implementer
 from zope.interface import Interface
 from zope.interface import Invalid
-from zope.interface import implementer
 from zope.interface import invariant
 
 
@@ -280,7 +280,7 @@ class IPatientSchema(model.Schema):
             raise Invalid(_("Patient email is invalid"))
 
 
-@implementer(IPatient, IPatientSchema)
+@implementer(IPatient, IPatientSchema, IClientShareable)
 class Patient(Container):
     """Results Interpretation Template content
     """

--- a/src/senaite/patient/profiles/default/rolemap.xml
+++ b/src/senaite/patient/profiles/default/rolemap.xml
@@ -24,28 +24,35 @@
       <role name="Manager"/>
     </permission>
 
-    <!-- Field permissions -->
+    <!-- Permissions for Sample fields
+    User who creates the object (Owner) has all rights granted by default
+    -->
     <permission name="senaite.patient: Field: Edit MRN" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
     <permission name="senaite.patient: Field: Edit Fullname" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
     <permission name="senaite.patient: Field: Edit Date of Birth" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
     <permission name="senaite.patient: Field: Edit Gender" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
     <permission name="senaite.patient: Field: Edit Address" acquire="False">
+      <role name="Owner"/>
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>

--- a/src/senaite/patient/profiles/default/types/Patient.xml
+++ b/src/senaite/patient/profiles/default/types/Patient.xml
@@ -52,6 +52,7 @@
     <element value="bika.lims.interfaces.IAutoGenerateID"/>
     <element value="bika.lims.interfaces.IMultiCatalogBehavior"/>
     <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
+    <element value="senaite.core.behaviors.IClientShareableBehavior" />
   </property>
 
   <!-- Action aliases -->

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
@@ -22,6 +22,7 @@
     <permission-map name="Access contents information" acquired="False">
       <!-- All except Anonymous and Client -->
       <permission-role>Analyst</permission-role>
+      <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>
@@ -37,6 +38,7 @@
     <permission-map name="List folder contents" acquired="False">
       <!-- All except Anonymous and Client -->
       <permission-role>Analyst</permission-role>
+      <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>
@@ -63,8 +65,9 @@
     </permission-map>
     <permission-map name="View" acquired="False">
       <!-- All except Anonymous -->
-      <permission-role>Client</permission-role>
       <permission-role>Analyst</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
@@ -9,6 +9,7 @@
              i18n:domain="senaite.patient">
 
   <!-- PLONE permissions -->
+  <permission>Add portal content</permission>
   <permission>Access contents information</permission>
   <permission>Delete objects</permission>
   <permission>List folder contents</permission>
@@ -29,6 +30,7 @@
       <permission-role>SamplingCoordinator</permission-role>
       <!-- Plone roles -->
       <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="Delete objects" acquired="False" />
@@ -45,13 +47,23 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Client</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <!-- Plone roles -->
+      <permission-role>Manager</permission-role>
+    </permission-map>
     <permission-map name="Modify portal content" acquired="False">
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
+      <!-- Plone roles -->
       <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
     </permission-map>
     <permission-map name="View" acquired="False">
       <!-- All except Anonymous and Client -->
+      <permission-role>Client</permission-role>
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
@@ -61,6 +73,7 @@
       <permission-role>SamplingCoordinator</permission-role>
       <!-- Plone roles -->
       <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
   </state>

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_workflow/definition.xml
@@ -48,6 +48,7 @@
     <permission-map name="View" acquired="False">
       <!-- All except Anonymous and Client -->
       <permission-role>Analyst</permission-role>
+      <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>

--- a/src/senaite/patient/tests/base.py
+++ b/src/senaite/patient/tests/base.py
@@ -76,7 +76,7 @@ class SimpleTestLayer(PloneSandboxLayer):
 SIMPLE_FIXTURE = SimpleTestLayer()
 SIMPLE_TESTING = FunctionalTesting(
     bases=(SIMPLE_FIXTURE, ),
-    name="senaite.storage:SimpleTesting"
+    name="senaite.patient:SimpleTesting"
 )
 
 

--- a/src/senaite/patient/tests/doctests/PatientWorkflow.rst
+++ b/src/senaite/patient/tests/doctests/PatientWorkflow.rst
@@ -75,7 +75,7 @@ Get the mapped workflow and status of the patient folder:
     >>> patients = portal.patients
 
     >>> api.get_workflows_for(patients)
-    ('senaite_one_state_workflow',)
+    ('senaite_patient_folder_workflow',)
 
     >>> api.get_workflow_status_of(patients)
     'active'
@@ -117,23 +117,23 @@ Field permission in **active** state:
 
     >>> from senaite.patient.permissions import FieldEditMRN
     >>> get_roles_for_permission(FieldEditMRN, patient)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditFullName
     >>> get_roles_for_permission(FieldEditFullName, patient)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditGender
     >>> get_roles_for_permission(FieldEditGender, patient)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditDateOfBirth
     >>> get_roles_for_permission(FieldEditDateOfBirth, patient)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditAddress
     >>> get_roles_for_permission(FieldEditAddress, patient)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
 Deactivating the patient
 
@@ -183,23 +183,23 @@ All patient fields are editable in `sample_due`:
 
     >>> from senaite.patient.permissions import FieldEditMRN
     >>> get_roles_for_permission(FieldEditMRN, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditFullName
     >>> get_roles_for_permission(FieldEditFullName, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditGender
     >>> get_roles_for_permission(FieldEditGender, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditDateOfBirth
     >>> get_roles_for_permission(FieldEditDateOfBirth, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditAddress
     >>> get_roles_for_permission(FieldEditAddress, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
 Receive the sample:
 
@@ -211,23 +211,23 @@ All patient fields are editable in `sample_received`:
 
     >>> from senaite.patient.permissions import FieldEditMRN
     >>> get_roles_for_permission(FieldEditMRN, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditFullName
     >>> get_roles_for_permission(FieldEditFullName, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditGender
     >>> get_roles_for_permission(FieldEditGender, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditDateOfBirth
     >>> get_roles_for_permission(FieldEditDateOfBirth, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditAddress
     >>> get_roles_for_permission(FieldEditAddress, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
 Set results and submit:
 
@@ -248,23 +248,23 @@ All patient fields are editable in `to_be_verified`:
 
     >>> from senaite.patient.permissions import FieldEditMRN
     >>> get_roles_for_permission(FieldEditMRN, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditFullName
     >>> get_roles_for_permission(FieldEditFullName, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditGender
     >>> get_roles_for_permission(FieldEditGender, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditDateOfBirth
     >>> get_roles_for_permission(FieldEditDateOfBirth, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> from senaite.patient.permissions import FieldEditAddress
     >>> get_roles_for_permission(FieldEditAddress, sample)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
 Verify the results:
 

--- a/src/senaite/patient/upgrade/v01_01_000.py
+++ b/src/senaite/patient/upgrade/v01_01_000.py
@@ -48,6 +48,7 @@ def upgrade(tool):
                                                    version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    setup.runImportStepFromProfile(profile, "typeinfo")
     setup.runImportStepFromProfile(profile, "rolemap")
     setup.runImportStepFromProfile(profile, "controlpanel")
     setup.runImportStepFromProfile(profile, "plone.app.registry")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Please merge https://github.com/senaite/senaite.patient/pull/37 and https://github.com/senaite/senaite.core/pull/2004 first**

This Pull Request makes possible to share patients across users from different clients. Also, system can be configured so patients are automatically shared with sample's client users when a sample with patient information is created.

![Captura de 2022-06-05 19-20-19](https://user-images.githubusercontent.com/832627/172062850-f67bbf73-8a10-4d81-bcf5-534d5ef38231.png)


## Current behavior before PR

- Cannot share patients across client users
- Patients created on sample creation are not visible to users from the client the sample belongs to

## Desired behavior after PR is merged

- Can share patients across client users
- System can be configured so patients created on sample creation become visible to users from the client the sample belongs to

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
