### PR TITLE
Add setting to display/hide temporary MRN icon in samples listing

### DIFF
--- a/src/senaite/patient/adapters/listing.py
+++ b/src/senaite/patient/adapters/listing.py
@@ -18,17 +18,17 @@
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from plone.memoize.instance import memoize
-from senaite.patient import check_installed
-from senaite.patient import messageFactory as _
 from senaite.app.listing.interfaces import IListingView
 from senaite.app.listing.interfaces import IListingViewAdapter
-from senaite.app.listing.utils import add_review_state
 from senaite.app.listing.utils import add_column
+from senaite.app.listing.utils import add_review_state
+from senaite.patient import check_installed
+from senaite.patient import messageFactory as _
 from zope.component import adapts
 from zope.component import getMultiAdapter
 from zope.interface import implements
-
 
 # Statuses to add. List of dicts
 ADD_STATUSES = [{
@@ -90,9 +90,18 @@ class SamplesListingAdapter(object):
     def icon_tag(self, name, **kwargs):
         return self.senaite_theme.icon_tag(name, **kwargs)
 
+    @property
+    @memoize
+    def show_icon_temp_mrn(self):
+        """Returns whether an alert icon has to be displayed next to the sample
+        id when the Patient assigned to the sample has a temporary Medical
+        Record Number (MRN)
+        """
+        return api.get_registry_record("senaite.patient.show_icon_temp_mrn")
+
     @check_installed(None)
     def folder_item(self, obj, item, index):
-        if obj.isMedicalRecordTemporary:
+        if self.show_icon_temp_mrn and obj.isMedicalRecordTemporary:
             # Add an icon after the sample ID
             after_icons = item["after"].get("getId", "")
             kwargs = {"width": 16, "title": _("Temporary MRN")}

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -112,6 +112,17 @@ class IPatientControlPanel(Interface):
         default=False,
     )
 
+    show_icon_temp_mrn = schema.Bool(
+        title=_(u"Display an alert icon on samples with a temporary MRN"),
+        description=_(
+            u"When selected, an alert icon is displayed in samples listing for "
+            u"samples that have a Patient assigned with a temporary Medical "
+            u"Record Number (MRN)."
+        ),
+        required=False,
+        default=True,
+    )
+
     share_patients = schema.Bool(
         title=_(u"Share patient on sample creation"),
         description=_(u"If selected, patients created or referred on sample "

--- a/src/senaite/patient/upgrade/v01_02_000.py
+++ b/src/senaite/patient/upgrade/v01_02_000.py
@@ -43,6 +43,7 @@ def upgrade(tool):
                                                    version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
 
     logger.info("{0} upgraded to version {1}".format(PRODUCT_NAME, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a new setting in patient's control panel that makes possible to hide/display the alert icon for temporary MRN on sampls listing

![Captura de 2022-06-13 13-58-03](https://user-images.githubusercontent.com/832627/173349149-f0a6892a-c65b-45d1-868b-ec3d071ab111.png)


## Current behavior before PR

An alert icon is displayed for samples with a temporary MRN

## Desired behavior after PR is merged

An alert icon is displayed for samples with a temporary MRN, but only if the setting is enabled

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
