### PR TITLE
Remove patients action link from inside Patient type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (2022-06-13)
 ------------------
 
+- #41 Remove patients action link from inside Patient context
 - #40 Add setting to display/hide temporary MRN icon in samples listing
 - Fix source distribution package (missing Changelog.rst file)
 

--- a/src/senaite/patient/profiles/default/types/Patient.xml
+++ b/src/senaite/patient/profiles/default/types/Patient.xml
@@ -61,18 +61,6 @@
   <alias from="sharing" to="@@sharing"/>
   <alias from="view" to="(selected layout)"/>
 
-  <!-- Patients Listing -->
-  <action title="Patients"
-          action_id="patients"
-          category="object"
-          condition_expr=""
-          description=""
-          icon_expr=""
-          link_target=""
-          url_expr="string:${folder_url}/patients" visible="True">
-    <permission value="View"/>
-  </action>
-
   <!-- View -->
   <action title="View"
           action_id="view"

--- a/src/senaite/patient/upgrade/v01_03_000.py
+++ b/src/senaite/patient/upgrade/v01_03_000.py
@@ -43,6 +43,18 @@ def upgrade(tool):
                                                    version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    del_patients_action(portal)
 
     logger.info("{0} upgraded to version {1}".format(PRODUCT_NAME, version))
     return True
+
+
+def del_patients_action(portal):
+    logger.info("Removing patients action from inside patient type ...")
+    type_info = portal.portal_types.getTypeInfo("Patient")
+    action_id = "patients"
+    actions = map(lambda action: action.id, type_info._actions)
+    if action_id in actions:
+        index = actions.index(action_id)
+        type_info.deleteActions([index])
+    logger.info("Removing patients action from inside patient type [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the "patients" action from inside "Patient" type

## Current behavior before PR

"Patients" action link is displayed in Patient's view

![Captura de 2022-06-17 18-32-47](https://user-images.githubusercontent.com/832627/174340085-9f817d2e-31da-4cbd-b93b-4db21958e27c.png)


## Desired behavior after PR is merged

"Patients" action link is not displayed in Patient's view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
