### PR TITLE
Remove dependency to Products.TextIndexNG3 (test layer)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (2022-06-13)
 ------------------
 
+- #42 Remove dependency to Products.TextIndexNG3 (test layer)
 - #41 Remove patients action link from inside Patient context
 - #40 Add setting to display/hide temporary MRN icon in samples listing
 - Fix source distribution package (missing Changelog.rst file)

--- a/src/senaite/patient/tests/base.py
+++ b/src/senaite/patient/tests/base.py
@@ -37,7 +37,6 @@ class SimpleTestLayer(PloneSandboxLayer):
     def setUpZope(self, app, configurationContext):
         super(SimpleTestLayer, self).setUpZope(app, configurationContext)
 
-        import Products.TextIndexNG3
         import bika.lims
         import senaite.core
         import senaite.app.listing
@@ -46,7 +45,6 @@ class SimpleTestLayer(PloneSandboxLayer):
         import senaite.patient
 
         # Load ZCML
-        self.loadZCML(package=Products.TextIndexNG3)
         self.loadZCML(package=bika.lims)
         self.loadZCML(package=senaite.core)
         self.loadZCML(package=senaite.app.listing)
@@ -55,7 +53,6 @@ class SimpleTestLayer(PloneSandboxLayer):
         self.loadZCML(package=senaite.patient)
 
         # Install product and call its initialize() function
-        zope.installProduct(app, "Products.TextIndexNG3")
         zope.installProduct(app, "bika.lims")
         zope.installProduct(app, "senaite.core")
         zope.installProduct(app, "senaite.app.listing")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the `Products.TextIndexNG3` dependency on the test layer because it is no longer a SENAITE dependency as per https://github.com/senaite/senaite.core/pull/2011 and https://github.com/senaite/senaite.core/pull/2014

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
