### PR TITLE
Allow to share patients with users from different clients groups

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (2022-06-13)
 ------------------
 
+- #43 Allow to share patients with users from different clients groups
 - #42 Remove dependency to Products.TextIndexNG3 (test layer)
 - #41 Remove patients action link from inside Patient context
 - #40 Add setting to display/hide temporary MRN icon in samples listing

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -123,11 +123,14 @@ class IPatientControlPanel(Interface):
         default=True,
     )
 
-    share_patients = schema.Bool(
+    share_strategy = schema.Choice(
         title=_(u"Share patient on sample creation"),
-        description=_(u"If selected, patients created or referred on sample "
-                      u"creation will automatically be shared across users "
-                      u"from same client the sample belongs to")
+        description=_(
+            u"Patients created or referred on sample creation will "
+            u"automatically be shared with other users in accordance with the "
+            u"selected strategy"
+        ),
+        source="senaite.patient.vocabularies.share_strategy",
     )
 
     @invariant

--- a/src/senaite/patient/config.py
+++ b/src/senaite/patient/config.py
@@ -50,3 +50,9 @@ IDENTIFIERS = (
     (u"driver_id", _(u"Driver ID")),
     (u"voter_id", _(u"Voter ID")),
 )
+
+SHARE_STRATEGIES = (
+    (u"", _(u"Do not share")),
+    (u"client", _(u"Share with client users")),
+    (u"clients_groups", _(u"Share with client groups users")),
+)

--- a/src/senaite/patient/configure.zcml
+++ b/src/senaite/patient/configure.zcml
@@ -40,6 +40,11 @@
       component="senaite.patient.vocabularies.NameEntryModesVocabularyFactory"
       name="senaite.patient.vocabularies.name_entry_modes" />
 
+  <!-- Sharing strategy vocabulary -->
+  <utility
+      component="senaite.patient.vocabularies.ShareStrategyVocabularyFactory"
+      name="senaite.patient.vocabularies.share_strategy" />
+
   <!-- Package includes -->
   <include package=".adapters" />
   <include package=".browser" />

--- a/src/senaite/patient/upgrade/v01_03_000.py
+++ b/src/senaite/patient/upgrade/v01_03_000.py
@@ -44,6 +44,7 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF BELOW --------
     del_patients_action(portal)
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
 
     logger.info("{0} upgraded to version {1}".format(PRODUCT_NAME, version))
     return True

--- a/src/senaite/patient/vocabularies.py
+++ b/src/senaite/patient/vocabularies.py
@@ -21,6 +21,7 @@
 from senaite.core.api.geo import get_countries
 from senaite.patient.config import GENDERS
 from senaite.patient.config import NAME_ENTRY_MODES
+from senaite.patient.config import SHARE_STRATEGIES
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
@@ -93,3 +94,17 @@ class NameEntryModesVocabulary(object):
 
 
 NameEntryModesVocabularyFactory = NameEntryModesVocabulary()
+
+
+@implementer(IVocabularyFactory)
+class ShareStrategyVocabulary(object):
+
+    def __call__(self, context):
+        items = [
+            # value, token, title
+            SimpleTerm(value, value, title) for value, title in SHARE_STRATEGIES
+        ]
+        return SimpleVocabulary(items)
+
+
+ShareStrategyVocabularyFactory = ShareStrategyVocabulary()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Please, merge https://github.com/senaite/senaite.core/pull/2046/** first

This Pull Request makes possible to share patients with users that belong to different clients thanks to the clients groups introduced with https://github.com/senaite/senaite.core/pull/2046/

There are now three options for automatic sharing of patients on creation:

- Do not share
- Share with users from same client
- Share with users from clients of same group

## Current behavior before PR

Is not possible to share patients automatically with multiple clients

## Desired behavior after PR is merged

Is possible to share patients automatically with multiple clients

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
