### PR TITLE
Added configuration option for Age introduction

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
+- #45 Added configuration option for Age introduction
 - #44 Added Sex as a different field from Gender
 
 

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -57,7 +57,15 @@ def get_patient_name_entry_mode():
 def is_gender_visible():
     """Checks whether the gender is visible
     """
-    return api.get_registry_record("senaite.patient.gender_visible")
+    key = "senaite.patient.gender_visible"
+    return api.get_registry_record(key, default=True)
+
+
+def is_age_supported():
+    """Returns whether the introduction of age is supported
+    """
+    key = "senaite.patient.age_supported"
+    return api.get_registry_record(key, default=True)
 
 
 def get_patient_by_mrn(mrn, full_object=True, include_inactive=False):

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -106,6 +106,18 @@ class IPatientControlPanel(Interface):
         default=True,
     )
 
+    age_supported = schema.Bool(
+        title=_(u"Age introduction"),
+        description=_(
+            u"If selected, a control for the introduction of either the age or "
+            u"date of birth will be displayed in Sample registration form and "
+            u"view. Otherwise, only the control for the introduction of the "
+            u"date of birth will be displayed"
+        ),
+        required=False,
+        default=True,
+    )
+
     verify_temp_mrn = schema.Bool(
         title=_(u"Allow to verify samples with a temporary MRN"),
         description=_(u"If selected, users will be able to verify samples "

--- a/src/senaite/patient/browser/widgets.py
+++ b/src/senaite/patient/browser/widgets.py
@@ -106,6 +106,11 @@ class AgeDoBWidget(DateTimeWidget):
             "days": delta.days,
         }
 
+    def is_age_supported(self, context):
+        """Returns whether the introduction of age is supported or not
+        """
+        return patient_api.is_age_supported()
+
     def process_form(self, instance, field, form, empty_marker=None,
                      emptyReturnsMarker=False, validating=True):
 

--- a/src/senaite/patient/content/analysisrequest.py
+++ b/src/senaite/patient/content/analysisrequest.py
@@ -27,6 +27,7 @@ from Products.Archetypes.Widget import StringWidget
 from Products.CMFCore.permissions import View
 from senaite.patient import messageFactory as _
 from senaite.patient.api import get_patient_name_entry_mode
+from senaite.patient.api import is_age_supported
 from senaite.patient.api import is_patient_required
 from senaite.patient.browser.widgets import AgeDoBWidget
 from senaite.patient.browser.widgets import FullnameWidget
@@ -120,7 +121,6 @@ DateOfBirthField = ExtDateTimeField(
     read_permission=View,
     write_permission=FieldEditDateOfBirth,
     widget=AgeDoBWidget(
-        label=_("Age / Date of birth"),
         render_own_label=True,
         default_age=True,
         show_time=False,
@@ -209,4 +209,12 @@ class AnalysisRequestSchemaModifier(object):
         entry_mode = get_patient_name_entry_mode()
         fullname_field = schema.get("PatientFullName")
         fullname_field.widget.entry_mode = entry_mode
+
+        # Change the name of the DoB's field label if Age is supported
+        field = schema.get("DateOfBirth")
+        if is_age_supported():
+            field.widget.label = _("Age / Date of birth")
+        else:
+            field.widget.label = _("Date of birth")
+
         return schema

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -38,7 +38,8 @@
           <div class="fieldErrorBox" tal:condition="required"></div>
 
           <!-- Age / DoB toggle radio -->
-          <div class="form-group mb-0">
+          <div class="form-group mb-0"
+               tal:condition="python:widget.is_age_supported(context)">
             <!-- age selector -->
             <input
               type="radio"
@@ -60,7 +61,8 @@
           </div>
 
           <!-- Age input area (keep outer container for visibility toggle) -->
-          <div tal:attributes="id string:${fieldName}_age_controls">
+          <div tal:attributes="id string:${fieldName}_age_controls"
+               tal:condition="python:widget.is_age_supported(context)">
             <div class="input-group flex-nowrap d-inline-flex w-auto">
               <input type="number" min='0' max='150'
                      class="form-control form-control-sm"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a new configuration option "Age" in patient's control panel. If the option is not selected, the introduction of Age won't be allowed, but Date of birth only

## Current behavior before PR

Users can set either the age or date of birth when registering samples

## Desired behavior after PR is merged

Users can set the age or date of birth when registering samples in accordance with the new configuration option

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
