### PR TITLE
Added config option to hide age's month and day when older than 1 year

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
+- #46 Added config option to hide age's month and day when older than 1 year
 - #45 Added configuration option for Age introduction
 - #44 Added Sex as a different field from Gender
 

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -68,6 +68,14 @@ def is_age_supported():
     return api.get_registry_record(key, default=True)
 
 
+def is_age_in_years():
+    """Returns whether the months and days should be omitted when displaying
+    the age of a patient when is greater than one year
+    """
+    key = "senaite.patient.age_years"
+    return api.get_registry_record(key, default=True)
+
+
 def get_patient_by_mrn(mrn, full_object=True, include_inactive=False):
     """Get a patient by Medical Record Number
 

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -118,6 +118,20 @@ class IPatientControlPanel(Interface):
         default=True,
     )
 
+    age_years = schema.Bool(
+        title=_(
+            u"label_controlpanel_patient_ageyears",
+            default=u"Age in years"),
+        description=_(
+            u"description_controlpanel_patient_ageyears",
+            default=u"If selected, months and days won't be displayed in "
+                    u"sample view if the age of the patient is greater than "
+                    u"one year. In such case, only years will be displayed"
+        ),
+        required=False,
+        default=True,
+    )
+
     verify_temp_mrn = schema.Bool(
         title=_(u"Allow to verify samples with a temporary MRN"),
         description=_(u"If selected, users will be able to verify samples "

--- a/src/senaite/patient/browser/widgets.py
+++ b/src/senaite/patient/browser/widgets.py
@@ -111,6 +111,16 @@ class AgeDoBWidget(DateTimeWidget):
         """
         return patient_api.is_age_supported()
 
+    def is_years_only(self, dob):
+        """Returns whether months and days are not displayed when the age is
+        greater than one year
+        """
+        if not patient_api.is_age_in_years():
+            return False
+        dob = self.get_current_age(dob)
+        years = dob.get("years", 0)
+        return years >= 1
+
     def process_form(self, instance, field, form, empty_marker=None,
                      emptyReturnsMarker=False, validating=True):
 

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -110,8 +110,8 @@
           </div>
 
           <!-- DoB input field -->
-          <div class="form-group"
-               tal:attributes="id string:${fieldName}_dob_controls">
+          <div tal:attributes="id string:${fieldName}_dob_controls">
+            <div class="input-group input-group-sm flex-nowrap d-inline-flex w-auto">
             <input type="date"
                    class="form-control form-control-sm"
                    tal:attributes="python:widget.attrs();
@@ -130,6 +130,7 @@
                          name string:${fieldName};
                          value string:${value}"/>
 
+          </div>
           </div>
         </div>
       </tal:values>

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -30,16 +30,19 @@
                           years python:current_age.get('years') or '';
                           months python:current_age.get('months') or '';
                           days python:current_age.get('days') or '';
-                          age_selected python:widget.get_age_selected(context);">
+                          age_selected python:widget.get_age_selected(context);
+                          age_supported python:widget.is_age_supported(context);
+                          years_only python:widget.is_years_only(value);
+                          show_months python:not years_only;
+                          show_days python:not years_only;">
 
         <div class="field AgeDoBWidget text-left"
              tal:attributes="data-required python:required and '1' or '0';
-                    data-fieldname string:${fieldName}">
+                             data-fieldname string:${fieldName}">
           <div class="fieldErrorBox" tal:condition="required"></div>
 
           <!-- Age / DoB toggle radio -->
-          <div class="form-group mb-0"
-               tal:condition="python:widget.is_age_supported(context)">
+          <div class="form-group mb-0" tal:condition="age_supported">
             <!-- age selector -->
             <input
               type="radio"
@@ -62,8 +65,8 @@
 
           <!-- Age input area (keep outer container for visibility toggle) -->
           <div tal:attributes="id string:${fieldName}_age_controls"
-               tal:condition="python:widget.is_age_supported(context)">
-            <div class="input-group input-group-sm">
+               tal:condition="age_supported">
+            <div class="input-group input-group-sm flex-nowrap d-inline-flex w-auto">
 
               <!-- Years -->
               <div class="input-group-prepend">
@@ -79,28 +82,30 @@
                            required python:required and 'required' or None;"/>
 
               <!-- Months -->
-              <div class="input-group-prepend ml-1">
+              <div class="input-group-prepend ml-1" tal:condition="show_months">
                 <label class="input-group-text"
                        tal:attributes="for string:${subfield_months}"
                        i18n:translate="">Months</label>
               </div>
-              <input type="number" value='' min='0' max='12' size='2'
+              <input value='' min='0' max='12' size='2'
                      class="form-control form-control-sm"
                      tal:attributes="id string:${subfield_months};
                            name string:${subfield_months};
-                           value months;"/>
+                           value months;
+                           type python: 'number' if show_months else 'hidden';"/>
 
               <!-- Days -->
-              <div class="input-group-prepend ml-1">
+              <div class="input-group-prepend ml-1" tal:condition="show_days">
                 <label class="input-group-text"
                        tal:attributes="for string:${subfield_days}"
                        i18n:translate="">Days</label>
               </div>
-              <input type="number" value='' min='0' max='31' size='2'
+              <input value='' min='0' max='31' size='2'
                      class="form-control form-control-sm"
                      tal:attributes="id string:${subfield_days};
                            name string:${subfield_days};
-                           value days;"/>
+                           value days;
+                           type python: 'number' if show_days else 'hidden';"/>
             </div>
           </div>
 

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -74,7 +74,7 @@
                        tal:attributes="for string:${subfield_years}"
                        i18n:translate="">Years</label>
               </div>
-              <input type="number" min='0' max='150' size='2'
+              <input type="number" min='0' max='150' size='3'
                      class="form-control form-control-sm"
                      tal:attributes="id string:${subfield_years};
                            name string:${subfield_years};
@@ -87,7 +87,7 @@
                        tal:attributes="for string:${subfield_months}"
                        i18n:translate="">Months</label>
               </div>
-              <input value='' min='0' max='12' size='2'
+              <input value='' min='0' max='12' size='3'
                      class="form-control form-control-sm"
                      tal:attributes="id string:${subfield_months};
                            name string:${subfield_months};
@@ -100,7 +100,7 @@
                        tal:attributes="for string:${subfield_days}"
                        i18n:translate="">Days</label>
               </div>
-              <input value='' min='0' max='31' size='2'
+              <input value='' min='0' max='31' size='3'
                      class="form-control form-control-sm"
                      tal:attributes="id string:${subfield_days};
                            name string:${subfield_days};

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -63,29 +63,41 @@
           <!-- Age input area (keep outer container for visibility toggle) -->
           <div tal:attributes="id string:${fieldName}_age_controls"
                tal:condition="python:widget.is_age_supported(context)">
-            <div class="input-group flex-nowrap d-inline-flex w-auto">
-              <input type="number" min='0' max='150'
+            <div class="input-group input-group-sm">
+
+              <!-- Years -->
+              <div class="input-group-prepend">
+                <label class="input-group-text"
+                       tal:attributes="for string:${subfield_years}"
+                       i18n:translate="">Years</label>
+              </div>
+              <input type="number" min='0' max='150' size='2'
                      class="form-control form-control-sm"
-                     title="Years"
-                     placeholder="Years"
-                     i18n:attributes="placeholder label_years"
                      tal:attributes="id string:${subfield_years};
                            name string:${subfield_years};
                            value years;
                            required python:required and 'required' or None;"/>
-              <input type="number" value='' min='0' max='12'
+
+              <!-- Months -->
+              <div class="input-group-prepend ml-1">
+                <label class="input-group-text"
+                       tal:attributes="for string:${subfield_months}"
+                       i18n:translate="">Months</label>
+              </div>
+              <input type="number" value='' min='0' max='12' size='2'
                      class="form-control form-control-sm"
-                     title="Months"
-                     placeholder="Months"
-                     i18n:attributes="placeholder label_months"
                      tal:attributes="id string:${subfield_months};
                            name string:${subfield_months};
                            value months;"/>
-              <input type="number" value='' min='0' max='31'
+
+              <!-- Days -->
+              <div class="input-group-prepend ml-1">
+                <label class="input-group-text"
+                       tal:attributes="for string:${subfield_days}"
+                       i18n:translate="">Days</label>
+              </div>
+              <input type="number" value='' min='0' max='31' size='2'
                      class="form-control form-control-sm"
-                     title="Days"
-                     placeholder="Days"
-                     i18n:attributes="placeholder label_days"
                      tal:attributes="id string:${subfield_days};
                            name string:${subfield_days};
                            value days;"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the "Age in years" configuration option in patient's control panel that makes the system "hide" the month and days from the Age widget when the patient is older than 1 year

![Captura de 2022-09-05 12-22-10](https://user-images.githubusercontent.com/832627/188427681-b002d3b7-1f00-4a1d-b4d6-d75427ed0efe.png)

When the option is selected, only the year is displayed if older than 1 year:

![Captura de 2022-09-05 12-12-51](https://user-images.githubusercontent.com/832627/188428066-d60c301d-1e04-4398-ace9-62ae1842e2d4.png)

Otherwise, all input fields are displayed. The styling of the widget has been improved as well, so the labels for "Years", "Months" and "Days" are always visible now (they are not placeholders anymore)

![Captura de 2022-09-05 12-24-34](https://user-images.githubusercontent.com/832627/188427810-7eddf24f-1f48-43b2-ad4c-11ca949e7179.png)


## Current behavior before PR

Months and days are always displayed on "Age" widget

## Desired behavior after PR is merged

Months and days are only displayed if the patient is younger than 1 year or if the configuration option "Age in years" is disabled

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
