### PR TITLE
Display "Estimated" next to date of birth when estimated from age

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
+- #47 Display "Estimated" next to date of birth when estimated from age
 - #46 Added config option to hide age's month and day when older than 1 year
 - #45 Added configuration option for Age introduction
 - #44 Added Sex as a different field from Gender

--- a/src/senaite/patient/browser/widgets.py
+++ b/src/senaite/patient/browser/widgets.py
@@ -172,7 +172,8 @@ class AgeDoBWidget(DateTimeWidget):
             dob = patient_api.get_birth_date(ymd)
 
             # Consider DoB as estimated?
-            orig_dob = value.get("original", None)
+            orig_dob = value.get("original")
+            orig_dob = patient_api.to_datetime(orig_dob)
             if not orig_dob:
                 # First time age is set, assume dob is estimated
                 self.set_dob_estimated(instance, True)
@@ -182,7 +183,6 @@ class AgeDoBWidget(DateTimeWidget):
                 # Age value in edit mode. We do not want the property
                 # "estimated" to change if he/she presses the Save button
                 # without the dob value being changed
-                orig_dob = patient_api.to_datetime(orig_dob)
                 if orig_dob.strftime("%y%m%d") != dob.strftime("%y%m%d"):
                     self.set_dob_estimated(instance, True)
         else:

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -52,16 +52,18 @@
               tal:attributes="id string:${fieldName}_age_selector;
                     checked python:age_selected;
                     name string:${subfield_selector}" />
-            <label tal:attributes="for string:${fieldName}_age_selector;">Age</label>
+            <label tal:attributes="for string:${fieldName}_age_selector;"
+                   i18n:translate="">Age</label>
 
             <!-- dob selector -->
             <input
               type="radio"
               value="dob"
-              tal:attributes="id string:${fieldName}DateOfBirth_dob_selector;
+              tal:attributes="id string:${fieldName}_dob_selector;
                     checked python:not age_selected;
                     name string:${subfield_selector}" />
-            <label tal:attributes="for string:${fieldName}_dob_selector">Date of Birth</label>
+            <label tal:attributes="for string:${fieldName}_dob_selector"
+                   i18n:translate="">Date of Birth</label>
 
           </div>
 

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -25,6 +25,7 @@
                           subfield_days string:${fieldName}.days:ignore_empty:record;
                           subfield_dob string:${fieldName}.dob:ignore_empty:record;
                           subfield_selector string:${fieldName}.selector:ignore_empty:record;
+                          subfield_original_value string:${fieldName}.original:ignore_empty:record;
                           required field/required|nothing;
                           current_age python:widget.get_current_age(value);
                           years python:current_age.get('years') or '';
@@ -32,6 +33,7 @@
                           days python:current_age.get('days') or '';
                           age_selected python:widget.get_age_selected(context);
                           age_supported python:widget.is_age_supported(context);
+                          dob_estimated python:widget.get_dob_estimated(context);
                           years_only python:widget.is_years_only(value);
                           show_months python:not years_only;
                           show_days python:not years_only;">
@@ -64,7 +66,8 @@
           </div>
 
           <!-- Age input area (keep outer container for visibility toggle) -->
-          <div tal:attributes="id string:${fieldName}_age_controls"
+          <div tal:attributes="id string:${fieldName}_age_controls;
+                               style python:'display:none' if not age_selected else ''"
                tal:condition="age_supported">
             <div class="input-group input-group-sm flex-nowrap d-inline-flex w-auto">
 
@@ -110,15 +113,30 @@
           </div>
 
           <!-- DoB input field -->
-          <div tal:attributes="id string:${fieldName}_dob_controls">
+          <div tal:attributes="id string:${fieldName}_dob_controls;
+                               style python:'display:none' if age_selected else ''">
             <div class="input-group input-group-sm flex-nowrap d-inline-flex w-auto">
-            <input type="date"
-                   class="form-control form-control-sm"
-                   tal:attributes="python:widget.attrs();
+              <input type="date"
+                     style="min-width:130px;max-width:130px"
+                     tal:define="invalid_class python: 'is-invalid' if dob_estimated else ''"
+                     tal:attributes="python:widget.attrs();
                          id string:${subfield_dob};
                          name string:${subfield_dob};
                          required python:required and 'required' or None;
-                         value python: widget.get_date(value) if value else '';"/>
+                         value python: widget.get_date(value) if value else '';
+                         class python: 'form-control form-control-sm {}'.format(invalid_class);"/>
+
+              <div tal:condition="dob_estimated"
+                   class="form-control form-control-sm text-danger border-danger">
+                <span i18n:translate="">Estimated</span>
+              </div>
+            </div>
+
+            <!-- Keep track of the old value -->
+            <input type="hidden"
+                   tal:attributes="id string:${subfield_original_value};
+                                   name string:${subfield_original_value};
+                                   value string:${value}"/>
 
             <!-- Field not visible for when the value is set automatically by
                  others through JS. When a value is set to this field, agedob widget
@@ -129,8 +147,6 @@
                    tal:attributes="id string:${fieldName}-dob-fallback;
                          name string:${fieldName};
                          value string:${value}"/>
-
-          </div>
           </div>
         </div>
       </tal:values>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a prominent label with the text "Estimated" next to the Date of Birth widget when the value is estimated from the value entered for Age. 

![Captura de 2022-09-06 22-29-55](https://user-images.githubusercontent.com/832627/188733666-e8cc7cb9-4113-4e15-a5ee-e24ee386ffd8.png)


## Current behavior before PR

Is not possible to know if the date of birth was estimated by the system from the age or it was actually entered by the user

## Desired behavior after PR is merged

System clearly indicates when the date of birth was estimated from age and when was entered manually

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
