### PR TITLE
Group configuration settings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
+- #49 Group configuration settings
 - #48 Add Patient middle name
 - #46 Added config option to hide age's month and day when older than 1 year
 - #45 Added configuration option for Age introduction

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -239,7 +239,8 @@ class IPatientControlPanel(Interface):
 class PatientControlPanelForm(RegistryEditForm):
     schema = IPatientControlPanel
     schema_prefix = "senaite.patient"
-    label = _("SENAITE Patient Settings")
+    label = _("Patient Settings")
+    description = _("Global settings for patients")
 
 
 PatientControlPanelView = layout.wrap_form(

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -23,6 +23,7 @@ import re
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
 from plone.app.registry.browser.controlpanel import RegistryEditForm
 from plone.autoform import directives
+from plone.supermodel import model
 from plone.z3cform import layout
 from senaite.core.schema.registry import DataGridRow
 from senaite.core.z3cform.widgets.datagrid import DataGridWidgetFactory
@@ -63,6 +64,39 @@ class IIdentifier(Interface):
 class IPatientControlPanel(Interface):
     """Controlpanel Settings
     """
+    ###
+    # Fieldsets
+    ###
+    model.fieldset(
+        "patient_field_settings",
+        label=_(u"Field Settings"),
+        description=_(""),
+        fields=[
+            "patient_entry_mode",
+            "age_supported",
+            "age_years",
+            "gender_visible",
+        ],
+    )
+
+    model.fieldset(
+        "patient_identifiers",
+        label=_(u"Identifiers"),
+        description=_(""),
+        fields=[
+            "identifiers",
+        ],
+    )
+
+    model.fieldset(
+        "patient_sharing",
+        label=_(u"Sharing"),
+        description=_(""),
+        fields=[
+            "share_patients",
+        ],
+    )
+
     require_patient = schema.Bool(
         title=_(u"Require Patient"),
         description=_("Require Patients in Samples"),

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -64,6 +64,7 @@ class IIdentifier(Interface):
 class IPatientControlPanel(Interface):
     """Controlpanel Settings
     """
+
     ###
     # Fieldsets
     ###
@@ -97,27 +98,45 @@ class IPatientControlPanel(Interface):
         ],
     )
 
+    ###
+    # Fields
+    ###
     require_patient = schema.Bool(
-        title=_(u"Require Patient"),
-        description=_("Require Patients in Samples"),
+        title=_(u"Require Medical Record Number (MRN)"),
+        description=_(
+            u"Make the MRN field mandatory in Sample Add form"
+        ),
         required=False,
         default=True,
     )
 
-    directives.widget(
-        "identifiers",
-        DataGridWidgetFactory,
-        auto_append=True)
-    identifiers = schema.List(
-        title=_(u"Identifiers"),
-        description=_(
-            u"List of identifiers that can be selected for a patient."
-        ),
-        value_type=DataGridRow(
-            title=u"Identifier",
-            schema=IIdentifier),
+    verify_temp_mrn = schema.Bool(
+        title=_(u"Allow to verify samples with a temporary MRN"),
+        description=_(u"If selected, users will be able to verify samples "
+                      u"that have a Patient assigned with a temporary Medical "
+                      u"Record Number (MRN)."),
         required=False,
-        defaultFactory=default_identifiers,
+        default=False,
+    )
+
+    publish_temp_mrn = schema.Bool(
+        title=_(u"Allow to publish samples with a temporary MRN"),
+        description=_(u"If selected, users will be able to publish samples "
+                      u"that have a Patient assigned with a temporary Medical "
+                      u"Record Number (MRN)."),
+        required=False,
+        default=False,
+    )
+
+    show_icon_temp_mrn = schema.Bool(
+        title=_(u"Display an alert icon on samples with a temporary MRN"),
+        description=_(
+            u"When selected, an alert icon is displayed in samples listing for "
+            u"samples that have a Patient assigned with a temporary Medical "
+            u"Record Number (MRN)."
+        ),
+        required=False,
+        default=True,
     )
 
     patient_entry_mode = schema.Choice(
@@ -166,33 +185,20 @@ class IPatientControlPanel(Interface):
         default=True,
     )
 
-    verify_temp_mrn = schema.Bool(
-        title=_(u"Allow to verify samples with a temporary MRN"),
-        description=_(u"If selected, users will be able to verify samples "
-                      u"that have a Patient assigned with a temporary Medical "
-                      u"Record Number (MRN)."),
-        required=False,
-        default=False,
-    )
-
-    publish_temp_mrn = schema.Bool(
-        title=_(u"Allow to publish samples with a temporary MRN"),
-        description=_(u"If selected, users will be able to publish samples "
-                      u"that have a Patient assigned with a temporary Medical "
-                      u"Record Number (MRN)."),
-        required=False,
-        default=False,
-    )
-
-    show_icon_temp_mrn = schema.Bool(
-        title=_(u"Display an alert icon on samples with a temporary MRN"),
+    directives.widget(
+        "identifiers",
+        DataGridWidgetFactory,
+        auto_append=True)
+    identifiers = schema.List(
+        title=_(u"Identifiers"),
         description=_(
-            u"When selected, an alert icon is displayed in samples listing for "
-            u"samples that have a Patient assigned with a temporary Medical "
-            u"Record Number (MRN)."
+            u"List of identifiers that can be selected for a patient."
         ),
+        value_type=DataGridRow(
+            title=u"Identifier",
+            schema=IIdentifier),
         required=False,
-        default=True,
+        defaultFactory=default_identifiers,
     )
 
     share_patients = schema.Bool(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds fielsets to the patient controlpanel for better handling

<img width="1013" alt="Patient Controlpanel" src="https://user-images.githubusercontent.com/713193/193255155-4b4ec6eb-4898-4316-a3f8-47590e4ac127.png">


## Current behavior before PR

Patient controlpanel showed all fields on one page

## Desired behavior after PR is merged

Patient controlpanel groups fields into meaningful fieldsets

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
