### PR TITLE
Allow additional email addresses for patients

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
+- #50 Allow additional email addresses for patients
 - #49 Group configuration settings
 - #48 Add Patient middle name
 - #46 Added config option to hide age's month and day when older than 1 year

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -544,6 +544,20 @@ class Patient(Container):
         mutator(self, api.safe_unicode(value.strip()))
 
     @security.protected(permissions.View)
+    def getAdditionalEmails(self):
+        """Returns the email with the field accessor
+        """
+        accessor = self.accessor("additional_emails")
+        return accessor(self) or []
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setAdditionalEmails(self, value):
+        """Set email by the field accessor
+        """
+        mutator = self.mutator("additional_emails")
+        mutator(self, value)
+
+    @security.protected(permissions.View)
     def getSex(self):
         """Returns the sex with the field accessor
         """

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -18,6 +18,8 @@
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from six import string_types
+
 from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims.api.mail import is_valid_email_address
@@ -42,11 +44,10 @@ from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.config import GENDERS
 from senaite.patient.config import SEXES
 from senaite.patient.interfaces import IPatient
-from six import string_types
 from zope import schema
-from zope.interface import implementer
 from zope.interface import Interface
 from zope.interface import Invalid
+from zope.interface import implementer
 from zope.interface import invariant
 
 

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -44,6 +44,7 @@ from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.config import GENDERS
 from senaite.patient.config import SEXES
 from senaite.patient.interfaces import IPatient
+from z3c.form.interfaces import NO_VALUE
 from zope import schema
 from zope.interface import Interface
 from zope.interface import Invalid
@@ -211,6 +212,7 @@ class IPatientSchema(model.Schema):
     directives.widget(
         "additional_emails",
         DataGridWidgetFactory,
+        allow_reorder=True,
         auto_append=True)
     additional_emails = DataGridField(
         title=_(
@@ -218,7 +220,7 @@ class IPatientSchema(model.Schema):
             default=u"Additional Emails"),
         description=_(
             u"description_patient_additional_emails",
-            default=u"Additional email addresses for this client"
+            default=u"Additional email addresses for this patient"
         ),
         value_type=DataGridRow(
             title=u"Email",
@@ -345,8 +347,9 @@ class IPatientSchema(model.Schema):
         """
         if not data.additional_emails:
             return
-
         for record in data.additional_emails:
+            if record == NO_VALUE:
+                continue
             email = record.get("email")
             if email and not is_valid_email_address(email):
                 raise Invalid(_("Email address %s is invalid" % email))

--- a/src/senaite/patient/tests/doctests/Patient.rst
+++ b/src/senaite/patient/tests/doctests/Patient.rst
@@ -1,0 +1,48 @@
+Patient Object
+--------------
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t Patient
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from bika.lims import api
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+    >>> patients = portal.patients
+
+
+Patients
+--------
+
+All patients are located in the patients folder:
+
+    >>> patient = api.create(patients, "Patient", mrn="1")
+    >>> patient
+    <Patient at /plone/patients/P000001>
+
+A patient can have a firstname, middlename and lastname:
+
+    >>> api.edit(patient, firstname="Bruce", middlename="Anthony", lastname="Wayne")
+    >>> patient.getFullname()
+    'Bruce Anthony Wayne'
+
+A patient can have a primary and additional email addresses:
+
+    >>> api.edit(patient, email="bruce@example.com",
+    ...          additional_emails=[{"name": "Work", "email": "wayne@example.com"}])
+
+    >>> patient.getEmail()
+    'bruce@example.com'
+
+    >>> patient.getAdditionalEmails()
+    [{'name': 'Work', 'email': 'wayne@example.com'}]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a new datagrid field to add multiple additional email addresses.

<img width="554" src="https://user-images.githubusercontent.com/713193/193293794-25b1380e-68a1-4245-a7ed-30d2cf686b8c.png">

## Current behavior before PR

Only one email address possible for a patient

## Desired behavior after PR is merged

Multiple (named) email addresses can be stored per patient

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
