### PR TITLE
Add patient marital status

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
-- no changes yet
+- #53 Add patient marital status
 
 
 1.3.0 (2022-10-03)

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -455,12 +455,12 @@ class IPatientControlPanel(Interface):
         old_keys = map(lambda i: i.get("key"), old_statuses)
         removed = list(set(old_keys).difference(keys))
 
-        if removed:
-            # check if there are patients that use one of the removed keys
-            brains = patient_search({"patient_marital_statuses_keys": removed})
+        for key in removed:
+            # check if there are patients that use one of the removed key
+            brains = patient_search({"patient_marital_status": key})
             if brains:
                 raise Invalid(
-                    _("Can not delete marital statuses that are in use"))
+                    _("Can not delete marital status that is in use"))
 
 
 class PatientControlPanelForm(RegistryEditForm):

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -279,6 +279,7 @@ class IPatientControlPanel(Interface):
     directives.widget(
         "identifiers",
         DataGridWidgetFactory,
+        allow_reorder=True,
         auto_append=True)
     identifiers = schema.List(
         title=_(u"Identifiers"),

--- a/src/senaite/patient/catalog/configure.zcml
+++ b/src/senaite/patient/catalog/configure.zcml
@@ -12,6 +12,7 @@
   <adapter name="patient_identifier_values" factory=".indexers.patient_identifier_values" />
   <adapter name="patient_race_keys" factory=".indexers.patient_race_keys" />
   <adapter name="patient_ethnicity_keys" factory=".indexers.patient_ethnicity_keys" />
+  <adapter name="patient_marital_status" factory=".indexers.patient_marital_status" />
   <adapter name="patient_email" factory=".indexers.patient_email" />
   <adapter name="patient_email_report" factory=".indexers.patient_email_report" />
   <adapter name="patient_birthdate" factory=".indexers.patient_birthdate" />

--- a/src/senaite/patient/catalog/indexers.py
+++ b/src/senaite/patient/catalog/indexers.py
@@ -70,6 +70,13 @@ def patient_ethnicity_keys(instance):
 
 
 @indexer(IPatient)
+def patient_marital_status(instance):
+    """Return patient marital status
+    """
+    return instance.getMaritalStatus()
+
+
+@indexer(IPatient)
 def patient_mrn(instance):
     """Index Medical Record #
     """

--- a/src/senaite/patient/catalog/patient_catalog.py
+++ b/src/senaite/patient/catalog/patient_catalog.py
@@ -36,6 +36,7 @@ INDEXES = BASE_INDEXES + [
     ("patient_identifier_values", "", "KeywordIndex"),
     ("patient_race_keys", "", "KeywordIndex"),
     ("patient_ethnicity_keys", "", "KeywordIndex"),
+    ("patient_marital_status", "", "FieldIndex"),
     ("patient_email", "", "FieldIndex"),
     ("patient_email_report", "", "BooleanIndex"),
     ("patient_fullname", "", "FieldIndex"),

--- a/src/senaite/patient/config.py
+++ b/src/senaite/patient/config.py
@@ -117,3 +117,20 @@ ETHNICITIES = (
     (u"OTH", _(u"other")),
     (u"UNK", _(u"unknown")),
 )
+
+
+# http://hl7.org/fhir/R4/valueset-marital-status.html
+MARITAL_STATUSES = (
+    (u"A", _(u"Annulled")),
+    (u"D", _(u"Divorced")),
+    (u"I", _(u"Interlocutory")),
+    (u"L", _(u"Legally Separated")),
+    (u"M", _(u"Married")),
+    (u"C", _(u"Common Law")),
+    (u"P", _(u"Polygamous")),
+    (u"T", _(u"Domestic partner")),
+    (u"U", _(u"unmarried")),
+    (u"S", _(u"Never Married")),
+    (u"W", _(u"Widowed")),
+    (u"UNK", _(u"unknown")),
+)

--- a/src/senaite/patient/configure.zcml
+++ b/src/senaite/patient/configure.zcml
@@ -34,6 +34,11 @@
       component="senaite.patient.vocabularies.EthnicitiesVocabularyFactory"
       name="senaite.patient.vocabularies.ethnicities" />
 
+  <!-- Marital Statuses Vocabulary -->
+  <utility
+      component="senaite.patient.vocabularies.MaritalStatusesVocabularyFactory"
+      name="senaite.patient.vocabularies.marital_statuses" />
+
   <!-- Sex Vocabulary -->
   <utility
       component="senaite.patient.vocabularies.SexVocabularyFactory"

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -222,6 +222,14 @@ class IPatientSchema(model.Schema):
         required=True,
     )
 
+    marital_status = schema.Choice(
+        title=_(u"label_patient_marital_status", default=u"Marital Status"),
+        description=_(u"Patient legally defined marital status"),
+        source="senaite.patient.vocabularies.marital_statuses",
+        default="UNK",
+        required=True,
+    )
+
     directives.widget(
         "races",
         DataGridWidgetFactory,

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -571,6 +571,20 @@ class Patient(Container):
         return mutator(self, value)
 
     @security.protected(permissions.View)
+    def getMaritalStatus(self):
+        """Returns the patient marital status
+        """
+        accessor = self.accessor("marital_status")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setMaritalStatus(self, value):
+        """Set the patient marital status
+        """
+        mutator = self.mutator("marital_status")
+        return mutator(self, value)
+
+    @security.protected(permissions.View)
     def getEmailReport(self):
         """Returns the email report option
         """

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1300</version>
+  <version>1401</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/patient/upgrade/configure.zcml
+++ b/src/senaite/patient/upgrade/configure.zcml
@@ -10,6 +10,9 @@
       handler="senaite.patient.upgrade.v01_04_000.upgrade"
       profile="senaite.patient:default"/>
 
+  <!-- Include all upgrade steps for 1.4.0 -->
+  <include file="v01_04_000.zcml" />
+
   <genericsetup:upgradeStep
       title="Upgrade to SENAITE PATIENT 1.3.0"
       source="1.2.0"

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -22,6 +22,7 @@ from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.patient import logger
 from senaite.patient.config import PRODUCT_NAME
+from senaite.patient.setuphandlers import setup_catalogs
 
 version = "1.4.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)
@@ -46,3 +47,20 @@ def upgrade(tool):
 
     logger.info("{0} upgraded to version {1}".format(PRODUCT_NAME, version))
     return True
+
+
+def upgrade_marital_status(tool):
+    """Update controlpanel and add index to patient catalog
+
+    :param tool: portal_setup tool
+    """
+    logger.info("Upgrade patient marital status ...")
+
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    # import registry
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
+    # setup patient catalog
+    setup_catalogs(portal)
+
+    logger.info("Upgrade patient marital status [DONCE]")

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <!-- Reindex QC Analyses
+       https://github.com/senaite/senaite.core/pull/2157 -->
+  <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Marital Status"
+      description="Update patient controlpanel and add catalog index"
+      source="1400"
+      destination="1401"
+      handler="senaite.patient.upgrade.v01_04_000.upgrade_marital_status"
+      profile="senaite.patient:default"/>
+
+</configure>

--- a/src/senaite/patient/vocabularies.py
+++ b/src/senaite/patient/vocabularies.py
@@ -51,7 +51,7 @@ class IdentifierVocabulary(object):
             # value, token, title
             term = SimpleTerm(keyword, keyword, title)
             items.append(term)
-        return SimpleVocabulary(sorted(items, key=lambda t: t.title))
+        return SimpleVocabulary(items)
 
 
 IdentifierVocabularyFactory = IdentifierVocabulary()
@@ -120,7 +120,7 @@ class RacesVocabulary(object):
             # value, token, title
             term = SimpleTerm(keyword, keyword, title)
             items.append(term)
-        return SimpleVocabulary(sorted(items, key=lambda t: t.title))
+        return SimpleVocabulary(items)
 
 
 RacesVocabularyFactory = RacesVocabulary()
@@ -141,7 +141,7 @@ class EthnicitiesVocabulary(object):
             # value, token, title
             term = SimpleTerm(keyword, keyword, title)
             items.append(term)
-        return SimpleVocabulary(sorted(items, key=lambda t: t.title))
+        return SimpleVocabulary(items)
 
 
 EthnicitiesVocabularyFactory = EthnicitiesVocabulary()
@@ -163,7 +163,7 @@ class MaritalStatusesVocabulary(object):
             # value, token, title
             term = SimpleTerm(keyword, keyword, title)
             items.append(term)
-        return SimpleVocabulary(sorted(items, key=lambda t: t.title))
+        return SimpleVocabulary(items)
 
 
 MaritalStatusesVocabularyFactory = MaritalStatusesVocabulary()

--- a/src/senaite/patient/vocabularies.py
+++ b/src/senaite/patient/vocabularies.py
@@ -145,3 +145,25 @@ class EthnicitiesVocabulary(object):
 
 
 EthnicitiesVocabularyFactory = EthnicitiesVocabulary()
+
+
+@implementer(IVocabularyFactory)
+class MaritalStatusesVocabulary(object):
+
+    def __call__(self, context):
+
+        marital_statuses = api.get_registry_record(
+            "senaite.patient.marital_statuses")
+
+        items = []
+        for marital_status in marital_statuses:
+            # note: the key will get the submitted value
+            keyword = marital_status.get("key")
+            title = marital_status.get("value")
+            # value, token, title
+            term = SimpleTerm(keyword, keyword, title)
+            items.append(term)
+        return SimpleVocabulary(sorted(items, key=lambda t: t.title))
+
+
+MaritalStatusesVocabularyFactory = MaritalStatusesVocabulary()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a new field to track the patient marital status:

<img width="461" src="https://user-images.githubusercontent.com/713193/195288186-e257db26-2ab2-4423-9f5a-76f98e6c66e8.png">

The default available marital statuses are defined according to http://hl7.org/fhir/R4/valueset-marital-status.html

This list can be modified in the patient control panel:

<img width="1072" src="https://user-images.githubusercontent.com/713193/195288615-28c126ea-4b09-4b07-8a7d-c3b9a47ab0aa.png">

 
## Current behavior before PR

Marital status not tracked for patients

## Desired behavior after PR is merged

Marital status is tracked for patients


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
