### PR TITLE
Allow to set additional named phone numbers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #54 Allow to set additional named phone numbers
 - #53 Add patient marital status
 
 

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -83,9 +83,14 @@ class IPatientSchema(model.Schema):
 
     # contact fieldset
     fieldset(
-        "contact",
-        label=u"Contact",
-        fields=["email", "additional_emails", "phone", "mobile"])
+        "email_and_phone",
+        label=u"Email and Phone",
+        fields=[
+            "email",
+            "additional_emails",
+            "phone",
+            "additional_phone_numbers",
+        ])
 
     # address fieldset
     fieldset(

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -223,7 +223,7 @@ class IPatientSchema(model.Schema):
     email = schema.TextLine(
         title=_(
             u"label_primary_patient_email",
-            default=u"Primary Email"
+            default=u"Primary Email Address"
         ),
         description=_(
             u"description_patient_primary_email",
@@ -240,7 +240,7 @@ class IPatientSchema(model.Schema):
     additional_emails = DataGridField(
         title=_(
             u"label_patient_additional_emails",
-            default=u"Additional Emails"),
+            default=u"Additional Email Addresses"),
         description=_(
             u"description_patient_additional_emails",
             default=u"Additional email addresses for this patient"

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -31,6 +31,7 @@ from Products.CMFCore import permissions
 from senaite.core.behaviors import IClientShareable
 from senaite.core.schema import AddressField
 from senaite.core.schema import DatetimeField
+from senaite.core.schema import PhoneField
 from senaite.core.schema.addressfield import OTHER_ADDRESS
 from senaite.core.schema.addressfield import PHYSICAL_ADDRESS
 from senaite.core.schema.addressfield import POSTAL_ADDRESS
@@ -38,6 +39,7 @@ from senaite.core.schema.fields import DataGridField
 from senaite.core.schema.fields import DataGridRow
 from senaite.core.z3cform.widgets.datagrid import DataGridWidgetFactory
 from senaite.core.z3cform.widgets.datetimewidget import DatetimeWidget
+from senaite.core.z3cform.widgets.phone import PhoneWidgetFactory
 from senaite.patient import api as patient_api
 from senaite.patient import messageFactory as _
 from senaite.patient.catalog import PATIENT_CATALOG
@@ -46,71 +48,15 @@ from senaite.patient.config import SEXES
 from senaite.patient.interfaces import IPatient
 from z3c.form.interfaces import NO_VALUE
 from zope import schema
-from zope.interface import Interface
 from zope.interface import Invalid
 from zope.interface import implementer
 from zope.interface import invariant
 
-
-class IIdentifiersSchema(Interface):
-    """Schema definition for identifier records field
-    """
-
-    key = schema.Choice(
-        title=_("Type"),
-        description=_(
-            u"The type of identifier that holds the ID"
-        ),
-        source="senaite.patient.vocabularies.identifiers",
-        required=True,
-    )
-
-    value = schema.TextLine(
-        title=_(u"ID"),
-        description=_(
-            u"The identification number of the selected identifier"
-        ),
-        required=True,
-    )
-
-
-class IAdditionalEmailSchema(Interface):
-    """Schema definition for additional emails field
-    """
-
-    name = schema.TextLine(
-        title=_("Name"),
-        description=_(u"Private, Work, Other etc."),
-        required=True,
-    )
-
-    email = schema.TextLine(
-        title=_(u"Email"),
-        description=_(u"Email address"),
-        required=True,
-    )
-
-
-class IRaceSchema(Interface):
-    """Schema definition for patient race
-    """
-    race = schema.Choice(
-        title=_("Race"),
-        description=_(u""),
-        source="senaite.patient.vocabularies.races",
-        required=False,
-    )
-
-
-class IEthnicitySchema(Interface):
-    """Schema definition for patient ethnicity
-    """
-    ethnicity = schema.Choice(
-        title=_("Ethnicity"),
-        description=_(u""),
-        source="senaite.patient.vocabularies.ethnicities",
-        required=False,
-    )
+from .schema import IAdditionalEmailSchema
+from .schema import IAdditionalPhoneNumbersSchema
+from .schema import IEthnicitySchema
+from .schema import IIdentifiersSchema
+from .schema import IRaceSchema
 
 
 class IPatientSchema(model.Schema):

--- a/src/senaite/patient/content/schema.py
+++ b/src/senaite/patient/content/schema.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+
+from plone.autoform import directives
+from senaite.core.schema import PhoneField
+from senaite.core.z3cform.widgets.phone import PhoneWidgetFactory
+from senaite.patient import messageFactory as _
+from zope import schema
+from zope.interface import Interface
+
+
+class IIdentifiersSchema(Interface):
+    """Schema definition for identifiers field
+    """
+    key = schema.Choice(
+        title=_(
+            u"label_patient_identifiers_key",
+            default=u"Type",
+        ),
+        description=_(
+            u"description_patient_identifiers_key",
+            default=u"The type of identifier that holds the ID",
+        ),
+        source="senaite.patient.vocabularies.identifiers",
+        required=True,
+    )
+
+    value = schema.TextLine(
+        title=_(
+            u"label_patient_identifiers_value",
+            default=u"ID",
+        ),
+        description=_(
+            u"description_patient_identifiers_value",
+            default=u"The identification number of the selected identifier",
+        ),
+        required=True,
+    )
+
+
+class IAdditionalEmailSchema(Interface):
+    """Schema definition for additional emails field
+    """
+    name = schema.TextLine(
+        title=_(
+            u"label_patient_additional_emails_name",
+            default="Name"
+        ),
+        description=_(
+            u"description_patient_additional_emails_name",
+            default=u"Private, Work, Other etc.",
+        ),
+        required=True,
+    )
+
+    email = schema.TextLine(
+        title=_(
+            u"label_patient_additional_emails_email",
+            default=u"Email",
+        ),
+        description=_(
+            u"description_patient_additional_emails_email",
+            default=u"Email address"),
+        required=True,
+    )
+
+
+class IAdditionalPhoneNumbersSchema(Interface):
+    """Schema definition for additional phone numbers field
+    """
+    name = schema.TextLine(
+        title=_(
+            u"label_patient_additional_phone_numbers_name",
+            default="Name",
+        ),
+        description=_(
+            u"description_patient_additional_phone_numbers_name",
+            default=u"Private, Work, Other etc."
+        ),
+        required=True,
+    )
+
+    directives.widget("phone", PhoneWidgetFactory)
+    phone = PhoneField(
+        title=_(
+            u"label_patient_additional_phone_numbers_phone",
+            default=u"Phone",
+        ),
+        description=_(
+            u"description_patient_additional_phone_numbers_phone",
+            default=u"Phone Number",
+        ),
+        required=True,
+    )
+
+    extension = schema.TextLine(
+        title=_(
+            u"label_patient_additional_phone_numbers_extension",
+            default=u"Extension"),
+        description=_(
+            u"description_patient_additional_phone_numbers_extension",
+            default=u"Phone Extension"
+        ),
+        required=False,
+    )
+
+
+class IRaceSchema(Interface):
+    """Schema definition for patient race
+    """
+    race = schema.Choice(
+        title=_(
+            u"label_patient_race",
+            default=u"Race",
+        ),
+        source="senaite.patient.vocabularies.races",
+        required=False,
+    )
+
+
+class IEthnicitySchema(Interface):
+    """Schema definition for patient ethnicity
+    """
+    ethnicity = schema.Choice(
+        title=_(
+            u"label_patient_ethnicity",
+            default=u"Ethnicity",
+        ),
+        source="senaite.patient.vocabularies.ethnicities",
+        required=False,
+    )

--- a/src/senaite/patient/content/schema.py
+++ b/src/senaite/patient/content/schema.py
@@ -92,17 +92,6 @@ class IAdditionalPhoneNumbersSchema(Interface):
         required=True,
     )
 
-    extension = schema.TextLine(
-        title=_(
-            u"label_patient_additional_phone_numbers_extension",
-            default=u"Extension"),
-        description=_(
-            u"description_patient_additional_phone_numbers_extension",
-            default=u"Phone Extension"
-        ),
-        required=False,
-    )
-
 
 class IRaceSchema(Interface):
     """Schema definition for patient race

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1401</version>
+  <version>1402</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -18,9 +18,11 @@
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.patient import logger
+from senaite.patient.api import patient_search
 from senaite.patient.config import PRODUCT_NAME
 from senaite.patient.setuphandlers import setup_catalogs
 
@@ -63,4 +65,21 @@ def upgrade_marital_status(tool):
     # setup patient catalog
     setup_catalogs(portal)
 
-    logger.info("Upgrade patient marital status [DONCE]")
+    logger.info("Upgrade patient marital status [DONE]")
+
+
+def upgrade_patient_mobile_phone_number(tool):
+    """Move mobile phone -> additional_phone_numbers records
+
+    :param tool: portal_setup tool
+    """
+    logger.info("Upgrade patient mobile number ...")
+
+    patients = patient_search({"portal_type": "Patient"})
+
+    for brain in patients:
+        patient = api.get_object(brain)
+        mobile = getattr(patient, "mobile", None)
+        # TBD
+
+    logger.info("Upgrade patient mobile number [DONE]")

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -87,6 +87,6 @@ def upgrade_patient_mobile_phone_number(tool):
         numbers = patient.getAdditionalPhoneNumbers()
         numbers.append({"name": "Mobile", "phone": mobile})
         patient.setAdditionalPhoneNumbers(numbers)
-        delattr(patient, mobile)
+        delattr(patient, "mobile")
 
     logger.info("Upgrade patient mobile number [DONE]")

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -80,6 +80,13 @@ def upgrade_patient_mobile_phone_number(tool):
     for brain in patients:
         patient = api.get_object(brain)
         mobile = getattr(patient, "mobile", None)
-        # TBD
+        if not mobile:
+            continue
+        logger.info("Moving mobile phone '%s' -> additional_phone_numbers"
+                    % mobile)
+        numbers = patient.getAdditionalPhoneNumbers()
+        numbers.append({"name": "Mobile", "phone": mobile})
+        patient.setAdditionalPhoneNumbers(numbers)
+        delattr(patient, mobile)
 
     logger.info("Upgrade patient mobile number [DONE]")

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,6 +2,16 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- Move mobile phone number to additional phone numbers
+       -->
+  <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Migrate mobile phone number"
+      description="Move mobile phone number to additional phone numbers record"
+      source="1401"
+      destination="1402"
+      handler="senaite.patient.upgrade.v01_04_000.upgrade_patient_mobile_phone_number"
+      profile="senaite.patient:default"/>
+
   <!-- Reindex QC Analyses
        https://github.com/senaite/senaite.core/pull/2157 -->
   <genericsetup:upgradeStep


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**NOTE ☝️: This PR requires https://github.com/senaite/senaite.core/pull/2165**

This PR allows to set additional named phone numbers per patient in a proper number format.

<img width="731" src="https://user-images.githubusercontent.com/713193/196114053-fbe5453a-13af-4824-8e68-399dc07ec565.png">

## Current behavior before PR

Only 2 emails allowed per patient

## Desired behavior after PR is merged

Multiple emails are allowed per patient

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
