### PR TITLE
Optional MRN in Patient Add/Edit forms

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #55 Optional MRN in Patient Add/Edit forms
 - #53 Add patient marital status
 
 

--- a/src/senaite/patient/browser/configure.zcml
+++ b/src/senaite/patient/browser/configure.zcml
@@ -9,6 +9,30 @@
   <include package=".viewlets"/>
   <include package=".widgets"/>
 
+  <!-- Add Patient view and form - invoked from ++add++ traverser -->
+  <adapter
+      for="Products.CMFCore.interfaces.IFolderish
+           senaite.patient.interfaces.ISenaitePatientLayer
+           plone.dexterity.interfaces.IDexterityFTI"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      factory=".views.PatientAddView"
+      name="Patient"/>
+
+  <class class=".views.PatientAddView">
+    <require
+        permission="cmf.AddPortalContent"
+        interface="zope.publisher.interfaces.browser.IBrowserPage"/>
+  </class>
+
+  <!-- Edit Patient -->
+  <browser:page
+      for="senaite.patient.interfaces.IPatient"
+      name="edit"
+      class=".views.PatientEditForm"
+      permission="cmf.ModifyPortalContent"
+      layer="senaite.patient.interfaces.ISenaitePatientLayer"
+      />
+
   <!-- Patient Folder View -->
   <browser:page
       name="view"

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -195,7 +195,8 @@ class IPatientControlPanel(Interface):
     require_patient = schema.Bool(
         title=_(u"Require Medical Record Number (MRN)"),
         description=_(
-            u"Make the MRN field mandatory in Sample Add form"
+            u"Make the MRN field mandatory in the sample registration form "
+            u"and when creating or modifiying patients."
         ),
         required=False,
         default=True,
@@ -222,9 +223,9 @@ class IPatientControlPanel(Interface):
     show_icon_temp_mrn = schema.Bool(
         title=_(u"Display an alert icon on samples with a temporary MRN"),
         description=_(
-            u"When selected, an alert icon is displayed in samples listing for "
-            u"samples that have a Patient assigned with a temporary Medical "
-            u"Record Number (MRN)."
+            u"When selected, an alert icon is displayed in samples listing "
+            u"for samples that have a Patient assigned with a temporary "
+            u"Medical Record Number (MRN)."
         ),
         required=False,
         default=True,

--- a/src/senaite/patient/browser/views.py
+++ b/src/senaite/patient/browser/views.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env zopepy
+
+import copy
+
+from plone.dexterity.browser import add
+from plone.dexterity.browser import edit
+from senaite.patient import messageFactory as _
+from senaite.patient.api import is_patient_required
+
+
+def fiddle_schema_fields(fields):
+    """ Modify schema fields
+    Code taken from:
+    https://docs.plone.org/develop/plone/forms/z3c.form.html#making-widgets-required-conditionally
+    """
+
+    # We need to override the actual required from the
+    # schema field which is a little tricky.
+    # Schema fields are shared between instances
+    # by default, so we need to create a copy of it
+    if not is_patient_required():
+        mrn = fields["mrn"]
+        mrn_field = copy.copy(mrn.field)
+        mrn_field.required = False
+        mrn.field = mrn_field
+
+
+class PatientAddForm(add.DefaultAddForm):
+    """Patient edit view
+    """
+    portal_type = "Patient"
+    default_fieldset_label = _("label_schema_personal", default=u"Personal")
+
+    def updateFieldsFromSchemata(self):
+        """see plone.autoform.base.AutoFields
+        """
+        super(PatientAddForm, self).updateFieldsFromSchemata()
+        fiddle_schema_fields(self.fields)
+
+
+class PatientAddView(add.DefaultAddView):
+    form = PatientAddForm
+
+    def __init__(self, context, request, ti=None):
+        super(PatientAddView, self).__init__(context, request, ti=ti)
+
+
+class PatientEditForm(edit.DefaultEditForm):
+    """Patient edit view
+    """
+    portal_type = "Patient"
+    default_fieldset_label = _("label_schema_personal", default=u"Personal")
+
+    def updateFieldsFromSchemata(self):
+        """see plone.autoform.base.AutoFields
+        """
+        super(PatientEditForm, self).updateFieldsFromSchemata()
+        fiddle_schema_fields(self.fields)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR makes the Patient MRN field optional in Add/Edit forms, if it is not set to mandatory in Patient setup:

<img width="1124" alt="" src="https://user-images.githubusercontent.com/713193/196278662-85d59a66-3ce9-484e-875b-a5e4ad197042.png">

<img width="849" alt="" src="https://user-images.githubusercontent.com/713193/196279166-b6139df7-3630-4668-8791-7f859a45033c.png">

<img width="1004" alt="" src="https://user-images.githubusercontent.com/713193/196279328-2286448c-93b4-4908-9908-f6c2e6ffdee1.png">

## Current behavior before PR

MRN was always required

## Desired behavior after PR is merged

MRN is not required if not set as mandatory in patient setup

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
