### PR TITLE
Fix unknown timezone error for birthdate in patient listing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #56 Fix unknown timezone error for birthdate in patient listing
 - #54 Allow to set additional named phone numbers
 - #55 Optional MRN in Patient Add/Edit forms
 - #53 Add patient marital status

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -28,6 +28,7 @@ from plone.dexterity.content import Container
 from plone.supermodel import model
 from plone.supermodel.directives import fieldset
 from Products.CMFCore import permissions
+from senaite.core.api import dtime
 from senaite.core.behaviors import IClientShareable
 from senaite.core.schema import AddressField
 from senaite.core.schema import DatetimeField
@@ -732,11 +733,15 @@ class Patient(Container):
         mutator(self, api.safe_unicode(value))
 
     @security.protected(permissions.View)
-    def getBirthdate(self):
+    def getBirthdate(self, as_date=True):
         """Returns the birthday with the field accessor
         """
         accessor = self.accessor("birthdate")
-        return accessor(self)
+        value = accessor(self)
+        # Return a plain date object to avoid timezone issues
+        if dtime.is_dt(value) and as_date:
+            value = value.date()
+        return value
 
     @security.protected(permissions.ModifyPortalContent)
     def setBirthdate(self, value):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following error that might occur for some timezones:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 236, in __call__
  Module senaite.app.listing.ajax, line 112, in handle_subpath
  Module senaite.core.decorators, line 22, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 460, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 339, in get_folderitems
  Module senaite.app.listing.view, line 963, in folderitems
  Module senaite.patient.browser.patientfolder, line 200, in folderitem
  Module bika.lims.browser, line 46, in ulocalized_time
  Module senaite.core.api.dtime, line 349, in to_localized_time
  Module senaite.core.api.dtime, line 117, in to_DT
  Module DateTime.DateTime, line 443, in __init__
  Module DateTime.DateTime, line 769, in _parse_args
DateTimeError: Unknown time zone in date: 2018-02-10T00:00:00+00:14
```

The `datetime` object contains the following timezone information:

```python
>>> birthdate
datetime.datetime(2018, 2, 10, 0, 0, tzinfo=<DstTzInfo 'Africa/Libreville' LMT+0:14:00 STD>)
>>> self.ulocalized_time(birthdate, long_format=0)
*** DateTimeError: Unknown time zone in date: 2018-02-10T00:00:00+00:14
```

Possible related issue:

https://github.com/zopefoundation/DateTime/issues/31


## Current behavior before PR

`DateTimeError` occurs for birthdates with timezone information stored

## Desired behavior after PR is merged

Birthdate is returned as `date` object per default

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
