### PR TITLE
Add sample field validation for patient ID

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #58 Add sample field validation for patient ID
 - #57 Patient samples listing and registration form
 - #54 Allow to set additional named phone numbers
 - #55 Optional MRN in Patient Add/Edit forms

--- a/src/senaite/patient/content/analysisrequest.py
+++ b/src/senaite/patient/content/analysisrequest.py
@@ -48,6 +48,8 @@ from senaite.patient.permissions import FieldEditGender
 from senaite.patient.permissions import FieldEditID
 from senaite.patient.permissions import FieldEditMRN
 from senaite.patient.permissions import FieldEditSex
+from senaite.patient.validators import PatientIDValidator
+from senaite.patient.validators import TemporaryIdentifierValidator
 from zope.component import adapts
 from zope.interface import implementer
 
@@ -59,7 +61,7 @@ MAYBE_REQUIRED_FIELDS = [
 MedicalRecordNumberField = TemporaryIdentifierField(
     "MedicalRecordNumber",
     required=True,
-    validators=("temporary_identifier_validator",),
+    validators=(TemporaryIdentifierValidator(), ),
     read_permission=View,
     write_permission=FieldEditMRN,
     widget=TemporaryIdentifierWidget(
@@ -75,6 +77,7 @@ MedicalRecordNumberField = TemporaryIdentifierField(
 
 PatientIDField = ExtStringField(
     "PatientID",
+    validators=(PatientIDValidator(), ),
     read_permission=View,
     write_permission=FieldEditID,
     widget=StringWidget(

--- a/src/senaite/patient/validators.py
+++ b/src/senaite/patient/validators.py
@@ -20,9 +20,10 @@
 
 from bika.lims import api
 from bika.lims.utils import to_utf8
-from senaite.patient import messageFactory as _
 from Products.validation import validation
 from Products.validation.interfaces.IValidator import IValidator
+from senaite.patient import messageFactory as _
+from senaite.patient.api import patient_search
 from zope.interface import implementer
 
 
@@ -50,3 +51,41 @@ class TemporaryIdentifierValidator(object):
 
 # Register validators
 validation.register(TemporaryIdentifierValidator())
+
+
+@implementer(IValidator)
+class PatientIDValidator(object):
+    """Verifies that the Patient ID is unique
+    """
+    name = "patient_id_validator"
+
+    def __call__(self, value, instance=None, *args, **kwargs):
+        field = kwargs.get("field", None)
+        if not field:
+            return True
+
+        # get the MRN from the request (might have changed as well)
+        request = instance.REQUEST
+        request_mrn = request.form.get("MedicalRecordNumber", {})
+        request_mrn_value = request_mrn.get("value")
+
+        query = {
+            "portal_type": "Patient",
+            "patient_id": api.safe_unicode(value).encode("utf8"),
+            "is_active": True,
+        }
+
+        patients = patient_search(query)
+
+        for patient in patients:
+            if patient.mrn != request_mrn_value:
+                msg = _("ID '%s' is already used for the patient MRN '%s'"
+                        % (value, patient.mrn))
+                ts = api.get_tool("translation_service")
+                return to_utf8(ts.translate(msg))
+
+        return True
+
+
+# Register validators
+validation.register(PatientIDValidator())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Please merge #57 first**

This PR adds a sample field validator when for the patient ID if the value was changed in the sample directly (over the sample header viewlet).

NOTE: This PR requires https://github.com/senaite/senaite.core/pull/2169 so that the field is properly indicated in the sample header viewlet

## Current behavior before PR

`ValueError` occured when the patient ID was not unique -> Viewlet rendered an error

## Desired behavior after PR is merged

Patient ID is properly validated if it does not belong to the same patient MRN.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
