### PR TITLE
Fix patient's middlename is not displayed in samples listing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #60 Fix patient's middlename is not displayed in samples listing
 - #59 Migrate Patient MRN/ID Sample Widgets to QuerySelect
 - #58 Add sample field validation for patient ID
 - #57 Patient samples listing and registration form

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -95,5 +95,6 @@ class FullnameField(ExtensionField, ObjectField):
 
     def get_fullname(self, instance):
         firstname = self.get_firstname(instance)
+        middlename = self.get_middlename(instance)
         lastname = self.get_lastname(instance)
-        return " ".join(filter(None, [firstname, lastname]))
+        return " ".join(filter(None, [firstname, middlename, lastname]))

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1404</version>
+  <version>1405</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -133,7 +133,7 @@ def get_patient_fields(instance):
         "gender": gender,
         "birthdate": birthdate,
         "address": address,
-        "firstname": firstname,
-        "middlename": middlename,
-        "lastname": lastname,
+        "firstname": api.safe_unicode(firstname),
+        "middlename": api.safe_unicode(middlename),
+        "lastname": api.safe_unicode(lastname),
     }

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,6 +2,15 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- 1405: Fix patient's middlename is not displayed in samples listing -->
+  <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Patient middle name is missing in samples"
+      description="Patient middle name is missing in samples listing"
+      source="1404"
+      destination="1405"
+      handler="senaite.patient.upgrade.v01_04_000.fix_samples_middlename"
+      profile="senaite.patient:default"/>
+
   <!-- 1404: Additional Indexes -->
   <genericsetup:upgradeStep
       title="SENAITE PATIENT 1.4.0: Additional patient search indexes"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When the patient name entry mode is set to "parts" (*First name + Last name*) in Patient settings, an input text area for the middle name is displayed in Add form, but the value is not kept later in samples listings, that in turn causes the system to alert that the patient name from the sample does not match with the "real" patient name

## Current behavior before PR

Patient middle name is not displayed as part of the patient's fullname in sample listings

## Desired behavior after PR is merged

Patient middle name is displayed as part of the patient's fullname in sample listings

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
