### PR TITLE
Fix Traceback in listing when fullname is different from sample's

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #61 Fix Traceback in listing when fullname is different from sample's
 - #59 Migrate Patient MRN/ID Sample Widgets to QuerySelect
 - #58 Add sample field validation for patient ID
 - #57 Patient samples listing and registration form

--- a/src/senaite/patient/adapters/listing.py
+++ b/src/senaite/patient/adapters/listing.py
@@ -140,19 +140,21 @@ class SamplesListingAdapter(object):
 
         # patient MRN is different
         if sample_patient_mrn != patient_mrn:
-            msg = _("Patient MRN of sample is not equal to %s" % (
-                patient_mrn or _("<no value>")))
-            icon_args = {"width": 16, "title": msg}
+            msg = _("Patient MRN of sample is not equal to %s")
+            val = api.safe_unicode(patient_mrn) or _("<no value>")
+            icon_args = {"width": 16, "title": api.to_utf8(msg % val)}
             item["after"]["MRN"] = self.icon_tag("info", **icon_args)
+
         if sample_patient_fullname != patient_fullname:
-            msg = _("Patient fullname of sample is not equal to %s" % (
-                patient_fullname or _("<no value>")))
-            icon_args = {"width": 16, "title": msg}
+            msg = _("Patient fullname of sample is not equal to %s")
+            val = api.safe_unicode(patient_fullname) or _("<no value>")
+            icon_args = {"width": 16, "title": api.to_utf8(msg % val)}
             item["after"]["Patient"] = self.icon_tag("info", **icon_args)
+
         if sample_patient_id != patient_id:
-            msg = _("Patient ID of sample is not equal to %s" % (
-                patient_id or _("<no value>")))
-            icon_args = {"width": 16, "title": msg}
+            msg = _("Patient ID of sample is not equal to %s")
+            val = api.safe_unicode(patient_id) or _("<no value>")
+            icon_args = {"width": 16, "title": api.to_utf8(msg % val)}
             item["after"]["PatientID"] = self.icon_tag("info", **icon_args)
 
     @viewcache


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that occurs when a patient with special characters in its fullname is registered in the system on sample creation and the patient fullname is changed in the sample afterwards. In such case, the system is meant to display an alert stating that the name of the patient set for the sample does not match with the name of the underlying patient

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 236, in __call__
  Module senaite.app.listing.ajax, line 112, in handle_subpath
  Module senaite.core.decorators, line 22, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 469, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 348, in get_folderitems
  Module senaite.app.listing.view, line 969, in folderitems
  Module senaite.patient, line 56, in wrapper
  Module senaite.patient.adapters.listing, line 149, in folder_item
  Module zope.i18nmessageid.message, line 112, in __call__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 56: ordinal not in range(128)
```

## Desired behavior after PR is merged

Samples listing is rendered correctly, as well as the patient fullname

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
