### PR TITLE
Added new name entry mode (firstname + lastname)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #62 Added new name entry mode (firstname + lastname)
 - #61 Fix Traceback in listing when fullname is different from sample's
 - #60 Fix patient's middlename is not displayed in samples listing
 - #59 Migrate Patient MRN/ID Sample Widgets to QuerySelect

--- a/src/senaite/patient/browser/patient/add2.py
+++ b/src/senaite/patient/browser/patient/add2.py
@@ -33,6 +33,11 @@ class PatientSampleAddView(BaseView):
                     "middlename": self.context.getMiddlename(),
                     "lastname": self.context.getLastname(),
                 }
+            elif entry_mode == "first_last":
+                return {
+                    "firstname": self.context.getFirstname(),
+                    "lastname": self.context.getLastname(),
+                }
             else:
                 return {"firstname": self.context.getFullname()}
         elif name == "PatientAddress":

--- a/src/senaite/patient/config.py
+++ b/src/senaite/patient/config.py
@@ -46,8 +46,18 @@ GENDERS = (
 )
 
 NAME_ENTRY_MODES = (
-    ("parts", _("First name + last name")),
-    ("full", _("Fullname")),
+    ("parts", _(
+        u"name_entry_mode_first_middle_last",
+        default=u"First + middle + last")
+     ),
+    ("first_last", _(
+        u"name_entry_mode_first_last",
+        default=u"First + last")
+     ),
+    ("full", _(
+        u"name_entry_mode_fullname",
+        default=u"Fullname")
+     ),
 )
 
 

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/fullnamewidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/fullnamewidget.pt
@@ -47,6 +47,8 @@
 
                           entry_mode python: field.widget.entry_mode or 'parts';
                           fullname_mode python: entry_mode in ['full', 'fullname'];
+                          first_last_mode python: entry_mode == 'first_last';
+                          parts_mode python: not any([fullname_mode, first_last_mode]);
                           i18n_domain field/widget/i18n_domain|context/i18n_domain|string:plone;">
 
         <div class="field FullnameWidget text-left"
@@ -72,6 +74,7 @@
                    title="Middlename"
                    placeholder="Middlename"
                    class="form-control form-control-sm mb-1"
+                   tal:condition="parts_mode"
                    i18n:attributes="placeholder label_middlename"
                    tal:attributes="id string:${subfield_middlename};
                                    name string:${subfield_middlename};


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds another option in name entry modes: "First + last"

## Current behavior before PR

Two name entry modes available: "Fullname" and "First + middle + last"

## Desired behavior after PR is merged

Three name entry modes available: "Fullname", "First + last" and "First + middle + last"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
