### PR TITLE
Fix Traceback in patient's samples view when name has special characters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #63 Fix Traceback in patient's samples view when name has special characters
 - #61 Fix Traceback in listing when fullname is different from sample's
 - #60 Fix patient's middlename is not displayed in samples listing
 - #59 Migrate Patient MRN/ID Sample Widgets to QuerySelect

--- a/src/senaite/patient/browser/patient/samples.py
+++ b/src/senaite/patient/browser/patient/samples.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from bika.lims import api
 from senaite.core.browser.samples.view import SamplesView as BaseView
 from senaite.patient import messageFactory as _
 
@@ -10,8 +11,8 @@ class SamplesView(BaseView):
     def __init__(self, context, request):
         super(SamplesView, self).__init__(context, request)
 
-        self.title = _("Samples of {}").format(
-            self.context.getFullname())
+        fullname = self.context.getFullname()
+        self.title = _("Samples of {}").format(api.safe_unicode(fullname))
 
         mrn = self.context.getMRN()
         if mrn:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a Traceback in patient's samples listing when the name of the patient contains special characters (e.g. "Ramón Turró")

## Current behavior before PR


```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 250, in publish
  Module ZPublisher.BaseRequest, line 518, in traverse
  Module ZPublisher.BaseRequest, line 349, in traverseName
  Module plone.dexterity.browser.traversal, line 52, in publishTraverse
  Module ZPublisher.BaseRequest, line 117, in publishTraverse
  Module zope.component._api, line 116, in queryMultiAdapter
  Module zope.interface.registry, line 365, in queryMultiAdapter
  Module zope.interface.adapter, line 844, in queryMultiAdapter
  Module senaite.patient.browser.patient.samples, line 13, in __init__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 13: ordinal not in range(128)
```

## Desired behavior after PR is merged

The samples listing of the Patient is displayed correctly without error

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
