### PR TITLE
Fix samples without patient middle name

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #64 Fix samples without patient middle name
 - #63 Fix Traceback in patient's samples view when name has special characters
 - #62 Added new name entry mode (firstname + lastname)
 - #61 Fix Traceback in listing when fullname is different from sample's

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -76,9 +76,11 @@ class FullnameField(ExtensionField, ObjectField):
     security = ClassSecurityInfo()
 
     def set(self, instance, value, **kwargs):
-        val = {"firstname": "", "middlename": "", "lastname": ""}
+        keys = ["firstname", "middlename", "lastname"]
+        val = dict([(key, "") for key in keys])
+
+        # Maybe fullname mode
         if isinstance(value, six.string_types):
-            # fullname mode
             val.update({"firstname": value})
 
         # Ensure the stored object is from dict type. The received value can
@@ -88,6 +90,12 @@ class FullnameField(ExtensionField, ObjectField):
 
         # Ensure the value contains expected keys
         val.update(value)
+
+        # Set default if no values for any of the keys
+        values = filter(None, [val.get(key) for key in keys])
+        if not any(values):
+            val = self.getDefault(instance)
+
         super(FullnameField, self).set(instance, val, **kwargs)
 
     def get_firstname(self, instance):

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -23,7 +23,6 @@ from AccessControl import ClassSecurityInfo
 from archetypes.schemaextender.field import ExtensionField
 from Products.Archetypes.Field import ObjectField
 from senaite.patient import api as patient_api
-from senaite.patient import logger
 from senaite.patient.browser.widgets import FullnameWidget
 from senaite.patient.browser.widgets import TemporaryIdentifierWidget
 from senaite.patient.config import AUTO_ID_MARKER

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -75,11 +75,20 @@ class FullnameField(ExtensionField, ObjectField):
     })
     security = ClassSecurityInfo()
 
-    def get(self, instance, **kwargs):
-        val = super(FullnameField, self).get(instance, **kwargs)
-        if isinstance(val, six.string_types):
-            val = {"firstname": val, "middlename": "", "lastname": ""}
-        return val
+    def set(self, instance, value, **kwargs):
+        val = {"firstname": "", "middlename": "", "lastname": ""}
+        if isinstance(value, six.string_types):
+            # fullname mode
+            val.update({"firstname": value})
+
+        # Ensure the stored object is from dict type. The received value can
+        # be from ZPublisher record type and since the field inherits from
+        # ObjectField, no conversion/decoding is done by the super field
+        value = dict(value) if value else {}
+
+        # Ensure the value contains expected keys
+        val.update(value)
+        super(FullnameField, self).set(instance, val, **kwargs)
 
     def get_firstname(self, instance):
         val = self.get(instance) or {}

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1405</version>
+  <version>1406</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/fullnamewidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/fullnamewidget.pt
@@ -80,6 +80,11 @@
                                    name string:${subfield_middlename};
                                    value middlename;
                                    required required;"/>
+            <input type="hidden"
+                   tal:condition="not:parts_mode"
+                   tal:attributes="id string:${subfield_middlename};
+                                   name string:${subfield_middlename};
+                                   value middlename;"/>
 
             <!-- Lastname -->
             <input type="text"

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -18,7 +18,6 @@
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-import six
 import transaction
 
 from bika.lims import api

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -137,8 +137,15 @@ def fix_samples_middlename(tool):
 
         obj = api.get_object(brain)
         brain_fullname = brain.getPatientFullName
-        obj_fullname = obj.getPatientFullName()
-        if obj_fullname != brain_fullname:
+        try:
+            obj_fullname = obj.getPatientFullName()
+            reindex = obj_fullname != brain_fullname
+        except AttributeError:
+            # AttributeError: 'unicode' object has no attribute 'get'
+            # Value is not stored as a dict. These cases are handled by 1406
+            reindex = False
+
+        if reindex:
             obj.reindexObject()
 
         # Flush the object from memory
@@ -184,6 +191,9 @@ def fix_samples_without_middlename(tool):
 
         # set the field value
         field.set(obj, value)
+
+        # reindex the object
+        obj.reindexObject()
 
         # Flush the object from memory
         obj._p_deactivate()

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -169,16 +169,19 @@ def fix_samples_without_middlename(tool):
         value = field.get(obj)
         if not value:
             continue
-        if "middlename" in value:
-            continue
+
         if isinstance(value, record):
             # found some ZPublisher records!!
             # (Pdb++) type(value)
             # <class 'ZPublisher.HTTPRequest.record'>
             value = dict(value)
 
+        if not isinstance(value, dict):
+            continue
+
         # set an empty middlename
-        value.update({"middlename": ""})
+        middlename = value.get("middlename", "")
+        value.update({"middlename": middlename})
         field.set(obj, value)
 
         # Flush the object from memory

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -28,7 +28,6 @@ from senaite.patient import logger
 from senaite.patient.api import patient_search
 from senaite.patient.config import PRODUCT_NAME
 from senaite.patient.setuphandlers import setup_catalogs
-from ZPublisher.HTTPRequest import record
 
 version = "1.4.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)
@@ -167,17 +166,21 @@ def fix_samples_without_middlename(tool):
         obj = api.get_object(brain)
         field = obj.getField("PatientFullName")
         value = field.get(obj)
-        if not value:
+        if value is None:
             continue
 
-        if isinstance(value, record):
+        if not isinstance(value, dict):
             # found some ZPublisher records!!
             # (Pdb++) type(value)
             # <class 'ZPublisher.HTTPRequest.record'>
             value = dict(value)
 
-        if not isinstance(value, dict):
-            continue
+        else:
+            # Do not update unless a key is missing
+            keys = ["firstname", "middlename", "lastname"]
+            exist = filter(lambda key: key in value, keys)
+            if len(exist) == len(keys):
+                continue
 
         # set an empty middlename
         middlename = value.get("middlename", "")

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -182,9 +182,7 @@ def fix_samples_without_middlename(tool):
             if len(exist) == len(keys):
                 continue
 
-        # set an empty middlename
-        middlename = value.get("middlename", "")
-        value.update({"middlename": middlename})
+        # set the field value
         field.set(obj, value)
 
         # Flush the object from memory

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -149,9 +149,8 @@ def fix_samples_middlename(tool):
 
 
 def fix_samples_without_middlename(tool):
-    """Reindex samples with a patient middle name set so the metadata
-    getPatientFullName gets populated correctly and therefore, and displayed
-    in samples listing as well
+    """Walks through registered samples and sets an empty middlename to those
+    that do not have a middle name set
     """
     logger.info("Fix samples without middle name ...")
     query = {"portal_type": "AnalysisRequest"}

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,6 +2,15 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- 1406: Fix samples without patient middle name -->
+  <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Fix samples without patient middle name"
+      description="Fix samples without patient middle name"
+      source="1405"
+      destination="1406"
+      handler="senaite.patient.upgrade.v01_04_000.fix_samples_without_middlename"
+      profile="senaite.patient:default"/>
+
   <!-- 1405: Fix patient's middlename is not displayed in samples listing -->
   <genericsetup:upgradeStep
       title="SENAITE PATIENT 1.4.0: Patient middle name is missing in samples"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an *error while rendering senaite.core.sampleheader* in sample view when the sample does not have a middle name set.

## Current behavior before PR

An *error while rendering senaite.core.sampleheader* is displayed instead of a sample header

## Desired behavior after PR is merged

The sample header is displayed correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
