### PR TITLE
Fix widget view mode

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #66 Fix widget view mode
 - #65 Fix cannot create partitions from samples with Patient assigned
 - #64 Fix samples without patient middle name
 - #63 Fix Traceback in patient's samples view when name has special characters

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -7,15 +7,37 @@
   <body>
 
     <metal:view_macro define-macro="view">
-      <tal:values define="age python:field.get_formatted_age(here);
-                          birth_date python:field.get_formatted_birth_date(here);">
+      <span metal:define-slot="inside"
+            tal:define="value accessor;
+                        dob_estimated python:widget.get_dob_estimated(context);
+                        current_age python:widget.get_current_age(value);
+                        years python:current_age.get('years') or '';
+                        months python:current_age.get('months') or '';
+                        days python:current_age.get('days') or '';
+                        value python: widget.ulocalized_time(value, context=context, request=request) if value else ''">
 
-        <span tal:content="age"/>
-        <tal:dob condition="birth_date">
-          (<span tal:content="birth_date"/>)
-        </tal:dob>
+        <!-- Date of birth -->
+        <span tal:condition="python:not dob_estimated">
+          <span tal:replace="value"></span>
+        </span>
 
-      </tal:values>
+        <!-- Age (estimated) -->
+        <span class="" tal:condition="python:dob_estimated">
+          <span tal:condition="python:years">
+            <span tal:replace="years"></span>
+            <span class="text-secondary" i18n:translate="patient_dob_years">Years</span>
+          </span>
+          <span tal:condition="python:months">
+            <span tal:replace="months"></span>
+            <span class="text-secondary" i18n:translate="patient_dob_months">Months</span>
+          </span>
+          <span tal:condition="python:days">
+            <span tal:replace="days"></span>
+            <span class="text-secondary" i18n:translate="patient_dob_days">Days</span>
+          </span>
+        </span>
+      </span>
+
     </metal:view_macro>
 
     <metal:edit_macro define-macro="edit">

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/fullnamewidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/fullnamewidget.pt
@@ -7,7 +7,7 @@
   <body>
 
     <metal:view_macro define-macro="view">
-      <tal:values define="value  python:field.getAccessor(here)();
+      <tal:values define="value  python:field.getAccessor(here)() or {};
                           firstname python:value.get('firstname', '');
                           middlename python:value.get('middlename', '');
                           lastname python:value.get('lastname', '');


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the view mode of the fullname- and dob widget.

NOTE: This PR depends on https://github.com/senaite/senaite.core/pull/2280


## Current behavior before PR

Tracebacks occur when rendering the sample header in view mode, e.g. for an Analyst

## Desired behavior after PR is merged

Fullname- and DoB widgets render correctly in view mode

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
