### PR TITLE
Compatibility with core#2279

### DIFF
--- a/src/senaite/patient/configure.zcml
+++ b/src/senaite/patient/configure.zcml
@@ -14,7 +14,7 @@
   <cmf:registerDirectory name="skins" directory="skins" recursive="True"/>
 
   <!-- Import senaite.core permissions -->
-  <include package="bika.lims" file="permissions.zcml" />
+  <include package="senaite.core.permissions" />
 
   <!-- Import senaite.patient permissions -->
   <include file="permissions.zcml" />


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Merge https://github.com/senaite/senaite.core/pull/2279 first

This Pull Request makes senaite.patient compatible with https://github.com/senaite/senaite.core/pull/2279

## Current behavior before PR

```
Traceback (most recent call last):
  File "/home/senaite/zinstance/parts/instance/bin/interpreter", line 351, in <module>
    exec(compile(__file__f.read(), __file__, "exec"))
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/Startup/serve.py", line 255, in <module>
    sys.exit(main() or 0)
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/Startup/serve.py", line 251, in main
    return command.run()
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/Startup/serve.py", line 190, in run
    global_conf=vars)
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/Startup/serve.py", line 220, in loadapp
    return loadapp(app_spec, name=name, relative_to=relative_to, **kw)
  File "/home/senaite/buildout-cache/eggs/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 253, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/home/senaite/buildout-cache/eggs/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 278, in loadobj
    return context.create()
  File "/home/senaite/buildout-cache/eggs/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 715, in create
    return self.object_type.invoke(self)
  File "/home/senaite/buildout-cache/eggs/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 209, in invoke
    app = context.app_context.create()
  File "/home/senaite/buildout-cache/eggs/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 715, in create
    return self.object_type.invoke(self)
  File "/home/senaite/buildout-cache/eggs/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 152, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/home/senaite/buildout-cache/eggs/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/Startup/run.py", line 72, in make_wsgi_app
    starter.prepare()
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/Startup/starter.py", line 41, in prepare
    self.startZope()
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/Startup/starter.py", line 99, in startZope
    Zope2.startup_wsgi()
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/__init__.py", line 50, in startup_wsgi
    _startup()
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/App/startup.py", line 143, in startup
    load_zcml()
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/App/startup.py", line 58, in load_zcml
    load_site()
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Zope2/App/zcml.py", line 45, in load_site
    _context = xmlconfig.file(site_zcml)
  File "/home/senaite/buildout-cache/eggs/zope.configuration-4.4.1-py2.7.egg/zope/configuration/xmlconfig.py", line 665, in file
    context.execute_actions()
  File "/home/senaite/buildout-cache/eggs/zope.configuration-4.4.1-py2.7.egg/zope/configuration/config.py", line 801, in execute_actions
    None, sys.exc_info()[2])
  File "/home/senaite/buildout-cache/eggs/zope.configuration-4.4.1-py2.7.egg/zope/configuration/config.py", line 791, in execute_actions
    callable(*args, **kw)
  File "/home/senaite/buildout-cache/eggs/AccessControl-4.3-py2.7-linux-x86_64.egg/AccessControl/security.py", line 170, in protectClass
    permission = getUtility(IPermission, name=permission_id)
  File "/home/senaite/buildout-cache/eggs/zope.component-4.6.2-py2.7.egg/zope/component/_api.py", line 165, in getUtility
    raise ComponentLookupError(interface, name)
zope.configuration.config.ConfigurationExecutionError: File "/home/senaite/src/senaite.patient/src/senaite/patient/browser/patient/configure.zcml", line 40.2-46.8
    <browser:page
        for="senaite.patient.interfaces.IPatient"
        name="ar_add"
        class=".add2.PatientSampleAddView"
        permission="senaite.core.permissions.AddAnalysisRequest"
        layer="senaite.patient.interfaces.ISenaitePatientLayer"
        />

    ComponentLookupError: (<InterfaceClass zope.security.interfaces.IPermission>, 'senaite.core.permissions.AddAnalysisRequest')
```

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
