### PR TITLE
Allow client local patients

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #68 Allow client local patients
 - #66 Fix widget view mode
 - #65 Fix cannot create partitions from samples with Patient assigned
 - #64 Fix samples without patient middle name

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -277,3 +277,30 @@ def to_identifier_type_name(identifier_type_key):
         name = record.get("value")
 
     return name
+
+
+def allow_patients_in_clients(allow=True):
+    """Allow patient creation in patients
+    """
+    pt = api.get_tool("portal_types")
+    # get the Client FTI
+    fti = pt.get("Client")
+    # get the current allowed types for the object
+    allowed_types = set(fti.allowed_content_types)
+    # Append or remove patient
+    if allow:
+        allowed_types.add("Patient")
+    else:
+        allowed_types.discard("Patient")
+    # set the new types
+    fti.allowed_content_types = tuple(allowed_types)
+
+    # Add view action
+
+
+def is_patient_allowed_in_client():
+    """Returns wether patients can be created in clients or not
+    """
+    allowed = api.get_registry_record(
+        "senaite.patient.allow_patients_in_clients", False)
+    return allowed

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -320,8 +320,8 @@ def allow_patients_in_clients(allow=True):
             ti._actions = tuple(actions)
     else:
         allowed_types.discard(PATIENT_TYPE)
-        if CLIENT_VIEW_ID in actions:
-            ti.deleteActions([actions.index(CLIENT_VIEW_ID)])
+        if CLIENT_VIEW_ID in action_ids:
+            ti.deleteActions([action_ids.index(CLIENT_VIEW_ID)])
 
     # set the new types
     fti.allowed_content_types = tuple(allowed_types)

--- a/src/senaite/patient/browser/client/configure.zcml
+++ b/src/senaite/patient/browser/client/configure.zcml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <!-- Patients View -->
+  <browser:page
+      name="patients"
+      for="bika.lims.interfaces.IClient"
+      class=".patients.PatientsView"
+      permission="zope2.View"
+      />
+
+</configure>

--- a/src/senaite/patient/browser/client/patients.py
+++ b/src/senaite/patient/browser/client/patients.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from senaite.patient.browser.patientfolder import PatientFolderView
+from senaite.patient.api import is_patient_allowed_in_client
 
 
 class PatientsView(PatientFolderView):
@@ -9,3 +10,7 @@ class PatientsView(PatientFolderView):
 
     def __init__(self, context, request):
         super(PatientsView, self).__init__(context, request)
+
+        # remove add action
+        if not is_patient_allowed_in_client():
+            self.context_actions = {}

--- a/src/senaite/patient/browser/client/patients.py
+++ b/src/senaite/patient/browser/client/patients.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from senaite.patient.browser.patientfolder import PatientFolderView
+
+
+class PatientsView(PatientFolderView):
+    """Client local patients
+    """
+
+    def __init__(self, context, request):
+        super(PatientsView, self).__init__(context, request)

--- a/src/senaite/patient/browser/configure.zcml
+++ b/src/senaite/patient/browser/configure.zcml
@@ -5,6 +5,7 @@
     i18n_domain="senaite.patient">
 
   <!-- Package includes -->
+  <include package=".client"/>
   <include package=".patient"/>
   <include package=".theme"/>
   <include package=".viewlets"/>

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -189,6 +189,7 @@ class IPatientControlPanel(Interface):
         description=_(""),
         fields=[
             "share_patients",
+            "allow_patients_in_clients",
         ],
     )
 
@@ -370,6 +371,11 @@ class IPatientControlPanel(Interface):
         description=_(u"If selected, patients created or referred on sample "
                       u"creation will automatically be shared across users "
                       u"from same client the sample belongs to")
+    )
+
+    allow_patients_in_clients = schema.Bool(
+        title=_(u"Allow patients in clients"),
+        description=_(u"If selected, patients can be created inside clients.")
     )
 
     @invariant

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1406</version>
+  <version>1407</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/patient/subscribers/configure.zcml
+++ b/src/senaite/patient/subscribers/configure.zcml
@@ -29,4 +29,10 @@
       handler=".patient.on_before_transition"
       />
 
+  <subscriber
+      for="senaite.patient.browser.controlpanel.IPatientControlPanel
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".controlpanel.on_patient_settings_changed"
+      />
+
 </configure>

--- a/src/senaite/patient/subscribers/controlpanel.py
+++ b/src/senaite/patient/subscribers/controlpanel.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from senaite.patient.api import allow_patients_in_clients
+
+
+def on_patient_settings_changed(object, event):
+    """Event handler when the patient settings changed
+    """
+    allow = object.allow_patients_in_clients
+    allow_patients_in_clients(allow)

--- a/src/senaite/patient/tests/base.py
+++ b/src/senaite/patient/tests/base.py
@@ -38,6 +38,7 @@ class SimpleTestLayer(PloneSandboxLayer):
         super(SimpleTestLayer, self).setUpZope(app, configurationContext)
 
         import bika.lims
+        import senaite.lims
         import senaite.core
         import senaite.app.listing
         import senaite.impress
@@ -46,6 +47,7 @@ class SimpleTestLayer(PloneSandboxLayer):
 
         # Load ZCML
         self.loadZCML(package=bika.lims)
+        self.loadZCML(package=senaite.lims)
         self.loadZCML(package=senaite.core)
         self.loadZCML(package=senaite.app.listing)
         self.loadZCML(package=senaite.impress)
@@ -54,6 +56,7 @@ class SimpleTestLayer(PloneSandboxLayer):
 
         # Install product and call its initialize() function
         zope.installProduct(app, "bika.lims")
+        zope.installProduct(app, "senaite.lims")
         zope.installProduct(app, "senaite.core")
         zope.installProduct(app, "senaite.app.listing")
         zope.installProduct(app, "senaite.impress")

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -201,3 +201,16 @@ def fix_samples_without_middlename(tool):
         obj._p_deactivate()
 
     logger.info("Fix samples without middle name [DONE]")
+
+
+def allow_patients_in_clients(tool):
+    """Allow to create patients inside clients
+    """
+    logger.info("Allow patients in clients ...")
+
+    # import registry for controlpanel
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
+
+    logger.info("Allow patients in clients [DONE]")

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,6 +2,15 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- 1407: Patients inside clients -->
+  <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Allow patients in clients"
+      description="Allow to create patients in the context of a client"
+      source="1406"
+      destination="1407"
+      handler="senaite.patient.upgrade.v01_04_000.allow_patients_in_clients"
+      profile="senaite.patient:default"/>
+
   <!-- 1406: Fix samples without patient middle name -->
   <genericsetup:upgradeStep
       title="SENAITE PATIENT 1.4.0: Fix samples without patient middle name"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to create patients inside client folders when enabled:

<img width="879" alt="SENAITE LIMS 2023-04-24 2 PM-19-02" src="https://user-images.githubusercontent.com/713193/233994168-014d3d72-c0e0-4990-a6ae-56b5e72bc7da.png">

<img width="1465" alt="Test external Lab — SENAITE LIMS 2023-04-24 2 PM-20-20" src="https://user-images.githubusercontent.com/713193/233994505-dc731029-27da-48d9-a789-682380f7f3ea.png">


## Current behavior before PR

Patients can be only created in global Patients folder

## Desired behavior after PR is merged

Patients can be created in clients folder as well

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
