### PR TITLE
Fix Patient Workflows and Permissions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #69 Fix Patient Workflows and Permissions
 - #68 Allow client local patients
 - #66 Fix widget view mode
 - #65 Fix cannot create partitions from samples with Patient assigned

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -22,10 +22,10 @@ import re
 from datetime import datetime
 
 from bika.lims import api
-from bika.lims.utils import get_client
 from bika.lims.utils import tmpID
 from dateutil.relativedelta import relativedelta
 from senaite.patient.config import PATIENT_CATALOG
+from senaite.patient.permissions import AddPatient
 from zope.component import getUtility
 from zope.component.interfaces import IFactory
 from zope.event import notify
@@ -156,18 +156,12 @@ def create_temporary_patient():
     return patient
 
 
-def store_temporary_patient(context, patient):
+def store_temporary_patient(container, patient):
     """Store temporary patient to the patients folder
 
-    :param context: The current context
+    :param container: The container where the patient should be stored
     :param patient: A temporary patient object
     """
-    if is_patient_allowed_in_client():
-        # create the patient inside the client
-        container = get_client(context)
-    else:
-        portal = api.get_portal()
-        container = portal.patients
     # Notify `ObjectCreateEvent` to generate a UID first
     notify(ObjectCreatedEvent(patient))
     # set the patient in the container
@@ -343,3 +337,22 @@ def is_patient_allowed_in_client():
     allowed = api.get_registry_record(
         "senaite.patient.allow_patients_in_clients", False)
     return allowed
+
+
+def get_patient_folder():
+    """Returns the global patient folder
+
+    :returns: global patients folder
+    """
+    portal = api.get_portal()
+    return portal.patients
+
+
+def is_patient_creation_allowed(container):
+    """Check if the security context allows to add a new patient
+
+    :param container: The container to check the permission
+    :returns: True if it is allowed to create a patient in the container,
+              otherwise False
+    """
+    return api.security.check_permission(AddPatient, container)

--- a/src/senaite/patient/browser/configure.zcml
+++ b/src/senaite/patient/browser/configure.zcml
@@ -16,7 +16,7 @@
       name="view"
       for="senaite.patient.content.patientfolder.IPatientFolder"
       class=".patientfolder.PatientFolderView"
-      permission="senaite.patient.permissions.ViewPatients"
+      permission="zope2.View"
       layer="senaite.patient.interfaces.ISenaitePatientLayer"
       />
 

--- a/src/senaite/patient/browser/configure.zcml
+++ b/src/senaite/patient/browser/configure.zcml
@@ -16,7 +16,8 @@
       name="view"
       for="senaite.patient.content.patientfolder.IPatientFolder"
       class=".patientfolder.PatientFolderView"
-      permission="zope2.View"
+      permission="senaite.patient.permissions.ViewPatients"
+      layer="senaite.patient.interfaces.ISenaitePatientLayer"
       />
 
   <!-- Patient Controlpanel -->
@@ -24,14 +25,16 @@
       name="patient-controlpanel"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       class=".controlpanel.PatientControlPanelView"
-      permission="senaite.core.permissions.ManageBika"
-      layer="senaite.patient.interfaces.ISenaitePatientLayer" />
+      permission="senaite.patient.permissions.ManagePatients"
+      layer="senaite.patient.interfaces.ISenaitePatientLayer"
+      />
 
   <!-- Static directory for js, css and image resources -->
   <plone:static
     directory="static"
     type="plone"
-    name="senaite.patient.static" />
+    name="senaite.patient.static"
+    />
 
   <!-- Static Resources Viewlet -->
   <browser:viewlet
@@ -40,6 +43,7 @@
     class="senaite.core.browser.viewlets.resources.ResourcesViewlet"
     permission="zope2.View"
     template="./static/resources.pt"
-    layer="senaite.patient.interfaces.ISenaitePatientLayer" />
+    layer="senaite.patient.interfaces.ISenaitePatientLayer"
+    />
 
 </configure>

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -57,7 +57,7 @@ class PatientFolderView(ListingView):
         self.context_actions = {
             _("Add"): {
                 "url": "++add++Patient",
-                "permission": "Add portal content",
+                "permission": "senaite.patient: Add Patient",
                 "icon": "++resource++bika.lims.images/add.png"}
             }
 

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -30,6 +30,7 @@ from senaite.patient import messageFactory as _sp
 from senaite.patient.api import to_identifier_type_name
 from senaite.patient.api import tuplify_identifiers
 from senaite.patient.catalog import PATIENT_CATALOG
+from senaite.patient.permissions import AddPatient
 
 
 class PatientFolderView(ListingView):
@@ -57,7 +58,7 @@ class PatientFolderView(ListingView):
         self.context_actions = {
             _("Add"): {
                 "url": "++add++Patient",
-                "permission": "senaite.patient: Add Patient",
+                "permission": AddPatient,
                 "icon": "++resource++bika.lims.images/add.png"}
             }
 

--- a/src/senaite/patient/configure.zcml
+++ b/src/senaite/patient/configure.zcml
@@ -85,6 +85,7 @@
     description="Run various configuration actions"
     handler=".setuphandlers.setup_handler">
     <depends name="typeinfo"/>
+    <depends name="workflow"/>
   </genericsetup:importStep>
 
   <!-- Uninstall profile -->

--- a/src/senaite/patient/permissions.py
+++ b/src/senaite/patient/permissions.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 ManagePatients = "senaite.patient: Manage Patients"
+ViewPatients = "senaite.patient: View Patients"
 
 AddPatientFolder = "senaite.patient: Add PatientFolder"
 AddPatient = "senaite.patient: Add Patient"

--- a/src/senaite/patient/permissions.py
+++ b/src/senaite/patient/permissions.py
@@ -18,11 +18,13 @@
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-ManagePatients = "senaite.patient: Manage Patients"
-ViewPatients = "senaite.patient: View Patients"
-
-AddPatientFolder = "senaite.patient: Add PatientFolder"
+# Add permission for our custom content types.
+# Slso see `initialize` function in `__init__.py`
 AddPatient = "senaite.patient: Add Patient"
+AddPatientFolder = "senaite.patient: Add PatientFolder"
+
+# Permission that governs the control panel view
+ManagePatients = "senaite.patient: Manage Patients"
 
 # Transition permissions
 TransitionActivate = "senaite.patient: Transition: Activate"

--- a/src/senaite/patient/permissions.zcml
+++ b/src/senaite/patient/permissions.zcml
@@ -3,11 +3,10 @@
     i18n_domain="senaite.patient">
 
   <permission id="senaite.patient.permissions.ManagePatients" title="senaite.patient: Manage Patients"/>
-  <permission id="senaite.patient.permissions.ViewPatients" title="senaite.patient: View Patients"/>
 
-  <!-- Content permissions -->
-  <permission id="senaite.patient.permissions.AddPatientFolder" title="senaite.patient: Add Patient Folder"/>
+  <!-- Add content permissions -->
   <permission id="senaite.patient.permissions.AddPatient" title="senaite.patient: Add Patient"/>
+  <permission id="senaite.patient.permissions.AddPatientFolder" title="senaite.patient: Add Patient Folder"/>
 
   <!-- Transition permissions -->
   <permission id="senaite.patient.permissions.TransitionActivate" title="senaite.patient: Transition: Activate"/>

--- a/src/senaite/patient/permissions.zcml
+++ b/src/senaite/patient/permissions.zcml
@@ -3,6 +3,7 @@
     i18n_domain="senaite.patient">
 
   <permission id="senaite.patient.permissions.ManagePatients" title="senaite.patient: Manage Patients"/>
+  <permission id="senaite.patient.permissions.ViewPatients" title="senaite.patient: View Patients"/>
 
   <!-- Content permissions -->
   <permission id="senaite.patient.permissions.AddPatientFolder" title="senaite.patient: Add Patient Folder"/>

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0"?>
-<!-- This file contains add-on dependency and version information. Is read
-  during Plone start-up and is required to be present and well-formatted for the
-  add-on to appear in the installer control panel.
-  If dependencies are defined, "portal_setup" installs the profiles listed as
-  dependencies before installing this add-on own profile.
--->
 <metadata>
-  <version>1407</version>
-
-  <!-- Be sure to install the following dependencies if not yet installed -->
+  <version>1408</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/profiles/default/rolemap.xml
+++ b/src/senaite/patient/profiles/default/rolemap.xml
@@ -14,6 +14,8 @@
       <role name="LabClerk"/>
       <role name="Manager"/>
       <role name="LabManager"/>
+      <!-- for client local patients -->
+      <role name="Owner"/>
     </permission>
 
     <!-- Add permissions -->
@@ -24,17 +26,24 @@
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <!-- for client local patients -->
+      <role name="Owner"/>
     </permission>
 
     <!-- Transition permissions -->
     <permission name="senaite.patient: Transition: Activate" acquire="False">
-      <role name="LabManager"/>
       <role name="LabClerk"/>
+      <role name="LabManager"/>
       <role name="Manager"/>
+      <!-- for client local patients -->
+      <role name="Owner"/>
     </permission>
     <permission name="senaite.patient: Transition: Deactivate" acquire="False">
+      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <!-- for client local patients -->
+      <role name="Owner"/>
     </permission>
 
     <!-- Permissions for Sample fields

--- a/src/senaite/patient/profiles/default/rolemap.xml
+++ b/src/senaite/patient/profiles/default/rolemap.xml
@@ -9,6 +9,13 @@
       <role name="LabManager"/>
     </permission>
 
+    <!-- View permissions -->
+    <permission name="senaite.patient: View Patients" acquire="False">
+      <role name="LabClerk"/>
+      <role name="Manager"/>
+      <role name="LabManager"/>
+    </permission>
+
     <!-- Add permissions -->
     <permission name="senaite.patient: Add Patient Folder" acquire="False">
       <role name="Manager"/>

--- a/src/senaite/patient/profiles/default/rolemap.xml
+++ b/src/senaite/patient/profiles/default/rolemap.xml
@@ -9,15 +9,6 @@
       <role name="LabManager"/>
     </permission>
 
-    <!-- View permissions -->
-    <permission name="senaite.patient: View Patients" acquire="False">
-      <role name="LabClerk"/>
-      <role name="Manager"/>
-      <role name="LabManager"/>
-      <!-- for client local patients -->
-      <role name="Owner"/>
-    </permission>
-
     <!-- Add permissions -->
     <permission name="senaite.patient: Add Patient Folder" acquire="False">
       <role name="Manager"/>

--- a/src/senaite/patient/profiles/default/types/PatientFolder.xml
+++ b/src/senaite/patient/profiles/default/types/PatientFolder.xml
@@ -82,7 +82,7 @@
           link_target=""
           url_expr="string:${object_url}"
           visible="True">
-    <permission value="View"/>
+    <permission value="senaite.patient: View Patients"/>
   </action>
 
   <!-- Edit -->

--- a/src/senaite/patient/profiles/default/types/PatientFolder.xml
+++ b/src/senaite/patient/profiles/default/types/PatientFolder.xml
@@ -82,7 +82,7 @@
           link_target=""
           url_expr="string:${object_url}"
           visible="True">
-    <permission value="senaite.patient: View Patients"/>
+    <permission value="View"/>
   </action>
 
   <!-- Edit -->

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
@@ -18,67 +18,40 @@
 
   <!-- State: active -->
   <state state_id="active" title="Active" i18n:attributes="title">
+
+    <!-- TRANSITIONS -->
     <exit-transition transition_id="" />
+    <!-- /TRANSITIONS -->
+
+    <!-- MANAGED PERMISSIONS -->
     <permission-map name="Access contents information" acquired="False">
-      <!-- All except Anonymous and Client -->
-      <permission-role>Analyst</permission-role>
-      <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-      <!-- Plone roles -->
       <permission-role>Manager</permission-role>
-      <permission-role>Owner</permission-role>
-      <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Delete objects" acquired="False" />
     <permission-map name="List folder contents" acquired="False">
-      <!-- All except Anonymous and Client -->
-      <permission-role>Analyst</permission-role>
-      <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-      <!-- Plone roles -->
       <permission-role>Manager</permission-role>
-      <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="Add portal content" acquired="False">
-      <permission-role>Client</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
-      <!-- Plone roles -->
       <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="Modify portal content" acquired="False">
-      <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
-      <!-- Plone roles -->
       <permission-role>Manager</permission-role>
-      <permission-role>Owner</permission-role>
     </permission-map>
     <permission-map name="View" acquired="False">
-      <!-- All except Anonymous -->
-      <permission-role>Analyst</permission-role>
-      <permission-role>Client</permission-role>
-      <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-      <!-- Plone roles -->
       <permission-role>Manager</permission-role>
-      <permission-role>Owner</permission-role>
-      <permission-role>Site Administrator</permission-role>
     </permission-map>
+    <!-- Do not allow to delete patients -->
+    <permission-map name="Delete objects" acquired="False" />
+    <!-- /MANAGED PERMISSIONS -->
+
   </state>
 
   <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
@@ -8,50 +8,65 @@
              manager_bypass="False"
              i18n:domain="senaite.patient">
 
-  <!-- PLONE permissions -->
+  <!-- MANAGED PERMISSIONS -->
   <permission>Add portal content</permission>
   <permission>Access contents information</permission>
   <permission>Delete objects</permission>
   <permission>List folder contents</permission>
   <permission>Modify portal content</permission>
   <permission>View</permission>
+  <!-- Custom Add permission to create Patients in this folder
+       Also see `initialize` function in `__init__.py`
+  -->
+  <permission>senaite.patient: Add Patient</permission>
+  <!-- /MANAGED PERMISSIONS -->
 
-  <!-- State: active -->
+
+  <!-- State: active (initial) -->
   <state state_id="active" title="Active" i18n:attributes="title">
 
     <!-- TRANSITIONS -->
     <exit-transition transition_id="" />
     <!-- /TRANSITIONS -->
 
-    <!-- MANAGED PERMISSIONS -->
+    <!-- PERMISSION MAPPINGS -->
+    <!-- This permission governs if the patients folder should appear in searches -->
     <permission-map name="Access contents information" acquired="False">
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
+    <!-- Inherit the default add permissions to allow add-ons to create other
+         contents besides patients w/o the need to change permissions. -->
+    <permission-map name="Add portal content" acquired="True">
+    </permission-map>
+    <!-- Roles that are needed to create a new Patient -->
+    <permission-map name="senaite.patient: Add Patient" acquired="False">
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <!-- Do not allow to delete patients (or other contents) of this folder -->
+    <permission-map name="Delete objects" acquired="False">
+    </permission-map>
+    <!-- Roles needed to list all patients -->
     <permission-map name="List folder contents" acquired="False">
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Add portal content" acquired="False">
-      <permission-role>LabClerk</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
+    <!-- Only the Manager can modify the folder -->
     <permission-map name="Modify portal content" acquired="False">
-      <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
+    <!-- Roles that are needed to see the patients folder / that it appears in
+         the side navigation bar -->
     <permission-map name="View" acquired="False">
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-    <!-- Do not allow to delete patients -->
-    <permission-map name="Delete objects" acquired="False" />
-    <!-- /MANAGED PERMISSIONS -->
-
+    <!-- /PERMISSION MAPPINGS -->
   </state>
 
   <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_folder_workflow/definition.xml
@@ -36,9 +36,12 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-    <!-- Inherit the default add permissions to allow add-ons to create other
-         contents besides patients w/o the need to change permissions. -->
-    <permission-map name="Add portal content" acquired="True">
+    <!-- Roles needed to add other contents inside the patients folder.
+         Not needed at the moment, but we use the default roles -->
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
     </permission-map>
     <!-- Roles that are needed to create a new Patient -->
     <permission-map name="senaite.patient: Add Patient" acquired="False">
@@ -46,7 +49,7 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-    <!-- Do not allow to delete patients (or other contents) of this folder -->
+    <!-- Never allow to delete contents -->
     <permission-map name="Delete objects" acquired="False">
     </permission-map>
     <!-- Roles needed to list all patients -->

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_workflow/definition.xml
@@ -8,21 +8,10 @@
              manager_bypass="False"
              i18n:domain="senaite.patient">
 
-  <!-- This governs whether you are allowed to delete some content in this folder. -->
-  <permission>Delete objects</permission>
-  <!-- This governs whether you are allowed to modify some content. -->
   <permission>Modify portal content</permission>
-  <!-- This governs whether you are allowed to view some content. -->
   <permission>View</permission>
-  <!-- This permission allows access to an object, without necessarily viewing the -->
-  <!-- object. For example, a user may want to see the object's title in a list of -->
-  <!-- results, even though the user can't view the contents of that file. -->
-  <permission>Access contents information</permission>
-  <!-- This governs whether you can get a listing of the contents of a folder; it -->
-  <!-- doesn't check whether you have the right to view the objects listed. -->
-  <permission>List folder contents</permission>
 
-  <!-- senaite.patient: Add  permissions -->
+  <!-- senaite.patient: Field permissions -->
   <permission>senaite.patient: Field: Edit MRN</permission>
   <permission>senaite.patient: Field: Edit ID</permission>
   <permission>senaite.patient: Field: Edit Fullname</permission>
@@ -37,31 +26,25 @@
 
   <!-- State: active -->
   <state state_id="active" title="Active" i18n:attributes="title">
-    <!-- Transitions -->
+
+    <!-- TRANSITIONS -->
     <exit-transition transition_id="deactivate" />
+    <!-- /TRANSITIONS -->
 
-    <!-- default permissions -->
-    <permission-map name="Access contents information" acquired="True" />
-    <permission-map name="Delete objects" acquired="True" />
-    <permission-map name="List folder contents" acquired="True" />
-    <permission-map name="Modify portal content" acquired="True" />
-
+    <!-- MANAGED PERMISSIONS -->
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
     <permission-map name="View" acquired="False">
-      <!-- All except Anonymous and Client -->
-      <permission-role>Analyst</permission-role>
       <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-      <!-- Plone roles -->
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
-      <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <!-- senaite.patient permissions -->
     <permission-map name="senaite.patient: Field: Edit MRN" acquired="True" />
     <permission-map name="senaite.patient: Field: Edit ID" acquired="True" />
     <permission-map name="senaite.patient: Field: Edit Fullname" acquired="True" />
@@ -69,21 +52,27 @@
     <permission-map name="senaite.patient: Field: Edit Gender" acquired="True" />
     <permission-map name="senaite.patient: Field: Edit Date of Birth" acquired="True" />
     <permission-map name="senaite.patient: Field: Edit Address" acquired="True" />
-    <!-- senaite.spatient Transition permissions -->
     <permission-map name="senaite.patient: Transition: Deactivate" acquired="True" />
+    <!-- /MANGED PERMISSIONS -->
+
   </state>
 
-  <!-- State: inactive -->
+  <!-- State: INACTIVE -->
   <state state_id="inactive" title="Inactive" i18n:attributes="title">
-    <!-- Transitions -->
+
+    <!-- TRANSITIONS -->
     <exit-transition transition_id="activate" />
-    <!-- Plone permission mappings -->
-    <permission-map name="Access contents information" acquired="True" />
-    <permission-map name="Delete objects" acquired="False" />
-    <permission-map name="List folder contents" acquired="True" />
+    <!-- /TRANSITIONS -->
+
+    <!-- MANAGED PERMISSIONS -->
     <permission-map name="Modify portal content" acquired="False" />
-    <permission-map name="View" acquired="True" />
-    <!-- senaite.patient permissions -->
+    <permission-map name="View" acquired="False">
+      <permission-role>ClientGuest</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
     <permission-map name="senaite.patient: Field: Edit MRN" acquired="False" />
     <permission-map name="senaite.patient: Field: Edit ID" acquired="False" />
     <permission-map name="senaite.patient: Field: Edit Fullname" acquired="False" />
@@ -91,8 +80,9 @@
     <permission-map name="senaite.patient: Field: Edit Gender" acquired="False" />
     <permission-map name="senaite.patient: Field: Edit Date of Birth" acquired="False" />
     <permission-map name="senaite.patient: Field: Edit Address" acquired="False" />
-    <!-- senaite.spatient Transition permissions -->
     <permission-map name="senaite.patient: Transition: Activate" acquired="True" />
+    <!-- /MANAGED PERMISSIONS -->
+
   </state>
 
   <!-- Transition: activate -->

--- a/src/senaite/patient/profiles/default/workflows/senaite_patient_workflow/definition.xml
+++ b/src/senaite/patient/profiles/default/workflows/senaite_patient_workflow/definition.xml
@@ -8,9 +8,13 @@
              manager_bypass="False"
              i18n:domain="senaite.patient">
 
+  <!-- MANAGED PERMISSIONS -->
+  <permission>Add portal content</permission>
+  <permission>Access contents information</permission>
+  <permission>Delete objects</permission>
+  <permission>List folder contents</permission>
   <permission>Modify portal content</permission>
   <permission>View</permission>
-
   <!-- senaite.patient: Field permissions -->
   <permission>senaite.patient: Field: Edit MRN</permission>
   <permission>senaite.patient: Field: Edit ID</permission>
@@ -19,10 +23,10 @@
   <permission>senaite.patient: Field: Edit Gender</permission>
   <permission>senaite.patient: Field: Edit Date of Birth</permission>
   <permission>senaite.patient: Field: Edit Address</permission>
-
   <!-- senaite.patient: Transition permissions -->
   <permission>senaite.patient: Transition: Activate</permission>
   <permission>senaite.patient: Transition: Deactivate</permission>
+  <!-- /MANAGED PERMISSIONS -->
 
   <!-- State: active -->
   <state state_id="active" title="Active" i18n:attributes="title">
@@ -32,12 +36,54 @@
     <!-- /TRANSITIONS -->
 
     <!-- MANAGED PERMISSIONS -->
+    <!-- This permission governs if a patient should appear in searches
+         NOTE: We add `ClientGuest` role here for shared patients, so that they
+               appear in the reference widget
+    -->
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>ClientGuest</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <!-- Roles needed to add contents inside patients.
+         Not needed at the moment, but we use the default roles -->
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <!-- Never allow to delete contents -->
+    <permission-map name="Delete objects" acquired="False">
+    </permission-map>
+    <!-- Roles needed to list contents in patients.
+         Not needed at the moment, but we use the default roles -->
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>ClientGuest</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <!-- We allow the Owner role here to edit client local patients, but not the
+         `ClientGuest` to edit shared patients! -->
     <permission-map name="Modify portal content" acquired="False">
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
     </permission-map>
+    <!-- We allow the `Owner` role to view patients, to allow client contacts to
+         see "client local" patients.
+
+         We also allow the `ClientGuest` role to view patients, if e.g. a lab
+         manager creates a sample with a patient referenced from the global
+         patients folder.
+         This allows to view the patient when clicked on the link inside the
+         samples listing w/o getting insufficient privileges
+    -->
     <permission-map name="View" acquired="False">
       <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -45,6 +91,8 @@
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
     </permission-map>
+
+    <!-- Custom field permissions (Use default roles from rolemap) -->
     <permission-map name="senaite.patient: Field: Edit MRN" acquired="True" />
     <permission-map name="senaite.patient: Field: Edit ID" acquired="True" />
     <permission-map name="senaite.patient: Field: Edit Fullname" acquired="True" />
@@ -65,7 +113,44 @@
     <!-- /TRANSITIONS -->
 
     <!-- MANAGED PERMISSIONS -->
-    <permission-map name="Modify portal content" acquired="False" />
+    <!-- This permission governs if a patient should appear in searches
+         NOTE: We add `ClientGuest` role here for shared patients, so that they
+               appear in the reference widget
+    -->
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>ClientGuest</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <!-- No longer allow to add contents to a deactivated patient -->
+    <permission-map name="Add portal content" acquired="False">
+    </permission-map>
+    <!-- Never allow to delete contents -->
+    <permission-map name="Delete objects" acquired="False">
+    </permission-map>
+    <!-- Roles needed to list contents in deactivated patients.
+         Not needed at the moment, but we use the default roles -->
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>ClientGuest</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <!-- Do not allow to edit deactivated patients -->
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
+    <!-- We allow the `Owner` role to view patients, to allow client contacts to
+         see "client local" patients.
+
+         We also allow the `ClientGuest` role to view patients, if e.g. a lab
+         manager creates a sample with a patient referenced from the global
+         patients folder.
+         This allows to view the patient when clicked on the link inside the
+         samples listing w/o getting insufficient privileges
+    -->
     <permission-map name="View" acquired="False">
       <permission-role>ClientGuest</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -73,6 +158,8 @@
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
     </permission-map>
+
+    <!-- Disallow to edit fields -->
     <permission-map name="senaite.patient: Field: Edit MRN" acquired="False" />
     <permission-map name="senaite.patient: Field: Edit ID" acquired="False" />
     <permission-map name="senaite.patient: Field: Edit Fullname" acquired="False" />

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/temporaryidentifierwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/temporaryidentifierwidget.pt
@@ -31,8 +31,6 @@
       <div class="form form-inline field ArchetypesTemporaryIdentifierWidget TemporaryIdentifier"
           tal:define="values python:field.getEditAccessor(here)() or {};
                       session_values python:here.session_restore_value(fieldName, values);
-                      cached_values python:request.get(fieldName, session_values);
-                      values python:cached_values or values;
                       value python: values.get('value', values.get('value_auto', ''));
                       value_auto values/value_auto|string:;
                       value_temp values/temporary|nothing;

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -97,7 +97,7 @@ def update_patient(instance):
     if patient is None:
         if patient_api.is_patient_allowed_in_client():
             # create the patient in the client
-            container = patient_api.get_patient_folder()
+            container = instance.getClient()
         else:
             # create the patient in the global patients folder
             container = patient_api.get_patient_folder()

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -98,7 +98,7 @@ def update_patient(instance):
         try:
             patient = patient_api.create_temporary_patient()
             patient_api.update_patient(patient, **values)
-            patient_api.store_temporary_patient(patient)
+            patient_api.store_temporary_patient(instance, patient)
         except ValueError as exc:
             logger.error("%s" % exc)
             logger.error("Failed to create patient for values: %r" % values)

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -93,6 +93,7 @@ def update_patient(instance):
     if mrn is None:
         return
     patient = patient_api.get_patient_by_mrn(mrn, include_inactive=True)
+    # Create a new patient
     if patient is None:
         if patient_api.is_patient_allowed_in_client():
             # create the patient in the client
@@ -107,7 +108,6 @@ def update_patient(instance):
                             api.user.get_user_id(), api.get_path(container)))
             # make the MRN temporary
             # XXX: Refactor logic from Widget -> Field/DataManager
-
             mrn_field = instance.getField("MedicalRecordNumber")
             mrn = dict(mrn_field.get(instance))
             mrn["temporary"] = True

--- a/src/senaite/patient/tests/base.py
+++ b/src/senaite/patient/tests/base.py
@@ -22,11 +22,14 @@ import transaction
 import unittest2 as unittest
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import applyProfile
 from plone.app.testing import setRoles
 from plone.testing import zope
+from plone.testing.z2 import Browser
 
 
 class SimpleTestLayer(PloneSandboxLayer):
@@ -38,11 +41,11 @@ class SimpleTestLayer(PloneSandboxLayer):
         super(SimpleTestLayer, self).setUpZope(app, configurationContext)
 
         import bika.lims
-        import senaite.lims
-        import senaite.core
         import senaite.app.listing
-        import senaite.impress
         import senaite.app.spotlight
+        import senaite.core
+        import senaite.impress
+        import senaite.lims
         import senaite.patient
 
         # Load ZCML
@@ -91,6 +94,23 @@ class SimpleTestCase(unittest.TestCase):
         self.request = self.layer["request"]
         self.request["ACTUAL_URL"] = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ["LabManager", "Manager"])
+
+    def getBrowser(self,
+                   username=TEST_USER_NAME,
+                   password=TEST_USER_PASSWORD,
+                   loggedIn=True):
+
+        # Instantiate and return a testbrowser for convenience
+        browser = Browser(self.portal)
+        browser.addHeader("Accept-Language", "en-US")
+        browser.handleErrors = False
+        if loggedIn:
+            browser.open(self.portal.absolute_url())
+            browser.getControl("Login Name").value = username
+            browser.getControl("Password").value = password
+            browser.getControl("Log in").click()
+            self.assertTrue("You are now logged in" in browser.contents)
+        return browser
 
 
 class FunctionalTestCase(unittest.TestCase):

--- a/src/senaite/patient/tests/doctests/PatientWorkflow.rst
+++ b/src/senaite/patient/tests/doctests/PatientWorkflow.rst
@@ -11,17 +11,23 @@ Test Setup
 Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from DateTime import DateTime
+    >>> from Products.CMFCore.permissions import AccessContentsInformation
+    >>> from Products.CMFCore.permissions import AddPortalContent
+    >>> from Products.CMFCore.permissions import DeleteObjects
+    >>> from Products.CMFCore.permissions import ListFolderContents
+    >>> from Products.CMFCore.permissions import ModifyPortalContent
+    >>> from Products.CMFCore.permissions import View
     >>> from bika.lims import api
+    >>> from bika.lims.api.security import get_roles_for_permission
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.utils.analysisrequest import create_partition
     >>> from bika.lims.workflow import doActionFor as do_action_for
-    >>> from bika.lims.workflow import isTransitionAllowed
     >>> from bika.lims.workflow import getAllowedTransitions
-    >>> from DateTime import DateTime
-    >>> from plone.app.testing import setRoles
+    >>> from bika.lims.workflow import isTransitionAllowed
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_PASSWORD
-    >>> from bika.lims.api.security import get_roles_for_permission
+    >>> from plone.app.testing import setRoles
 
 Functional Helpers:
 
@@ -67,8 +73,8 @@ We need to create some basic objects for the test:
     >>> MS = api.create(setup.bika_analysisservices, "AnalysisService", title="Malaria Species", Keyword="MS", Price="10", Category=category.UID(), Accredited=True)
 
 
-Patient Folder Permissions
-..........................
+Patient Folder Workflow
+.......................
 
 Get the mapped workflow and status of the patient folder:
 
@@ -80,19 +86,55 @@ Get the mapped workflow and status of the patient folder:
     >>> api.get_workflow_status_of(patients)
     'active'
 
-Global add permission:
+
+Patient Folder Permissions
+..........................
+
+The creation of a patients folder is governed with the custom `AddPatientFolder` permission.
+Also see the `initialize` function in `__init__.py`.
 
     >>> from senaite.patient.permissions import AddPatientFolder
     >>> get_roles_for_permission(AddPatientFolder, portal)
     ['Manager']
 
-    >>> from senaite.patient.permissions import AddPatient
-    >>> get_roles_for_permission(AddPatient, patients)
-    ['LabClerk', 'LabManager', 'Manager', 'Owner']
+The `View` permission governs who is allowed to see the patients folder and if
+it is displayed in the side navigation or not:
+
+    >>> get_roles_for_permission(View, patients)
+    ['LabClerk', 'LabManager', 'Manager']
+
+The `DeleteObjects` permission governs if it is allowed to delete *any kind of
+objects* from this folder:
+
+    >>> get_roles_for_permission(DeleteObjects, patients)
+    []
+
+The `AccessContentsInformation` permission governs if the basic access to the
+folder, without necessarily viewing it:
+
+    >>> get_roles_for_permission(AccessContentsInformation, patients)
+    ['LabClerk', 'LabManager', 'Manager']
+
+The `ListFolderContents` permission governs whether you can get a listing of the patients:
+
+    >>> get_roles_for_permission(ListFolderContents, patients)
+    ['LabClerk', 'LabManager', 'Manager']
+
+The `ModifyPortalContent` permission governs whether it is allowed to change e.g. the Title of the folder:
+
+    >>> get_roles_for_permission(ModifyPortalContent, patients)
+    ['Manager']
 
 
 Patient Permissions
 ...................
+
+The creation of a patients is governed with the custom `AddPatient` permission.
+Also see the `initialize` function in `__init__.py`.
+
+    >>> from senaite.patient.permissions import AddPatient
+    >>> get_roles_for_permission(AddPatient, patients)
+    ['LabClerk', 'LabManager', 'Manager']
 
 Create a new patient:
 

--- a/src/senaite/patient/tests/doctests/PatientWorkflow.rst
+++ b/src/senaite/patient/tests/doctests/PatientWorkflow.rst
@@ -155,6 +155,52 @@ Allowed transitions:
    >>> getAllowedTransitions(patient)
    ['deactivate']
 
+
+Default permissions in **active** state:
+
+The following roles can `Access contents information` of patients, e.g. to see
+the results in the reference widget:
+
+    >>> get_roles_for_permission(AccessContentsInformation, patient)
+    ['ClientGuest', 'LabClerk', 'LabManager', 'Manager', 'Owner']
+
+The `AddPortalContent` permission governs wether it is allowed to add contents
+inside a patient.
+
+Although it is not used currently, we use the default permissions including the
+`Owner` for client-local patients:
+
+    >>> get_roles_for_permission(AddPortalContent, patient)
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
+
+The `DeleteObjects` permission governs wether it is allowed to removed contents
+inside a patient. We (almost) never allow this:
+
+    >>> get_roles_for_permission(DeleteObjects, patient)
+    []
+
+The `ListFolderContents` permission governs wether it is allowed list contents
+inside patients.
+
+Although it is not used currently, we use the default roles including the
+`Owner` for client-local and `ClientGuest` for shared patients:
+
+    >>> get_roles_for_permission(ListFolderContents, patient)
+    ['ClientGuest', 'LabClerk', 'LabManager', 'Manager', 'Owner']
+
+The `ModifyPortalContent` permission governs wether it is allowed to edit a patient.
+Note that we do not allow this for `ClientGuest` role, because we do not want that
+shared patients can be edited from basically client contacts:
+
+    >>> get_roles_for_permission(ModifyPortalContent, patient)
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
+
+The `View` permission governs if the patient can be viewed:
+
+    >>> get_roles_for_permission(View, patient)
+    ['ClientGuest', 'LabClerk', 'LabManager', 'Manager', 'Owner']
+
+
 Field permission in **active** state:
 
     >>> from senaite.patient.permissions import FieldEditMRN
@@ -186,6 +232,40 @@ Deactivating the patient
     >>> transitioned = do_action_for(patient, "deactivate")
     >>> api.get_workflow_status_of(patient)
     'inactive'
+
+
+Default permissions in **inactive** state:
+
+Accessing the patient is possible for the same roles:
+
+    >>> get_roles_for_permission(AccessContentsInformation, patient)
+    ['ClientGuest', 'LabClerk', 'LabManager', 'Manager', 'Owner']
+
+It should be no longer possible to add contents to a deactivated patient:
+
+    >>> get_roles_for_permission(AddPortalContent, patient)
+    []
+
+Deleting contents is not allowed:
+
+    >>> get_roles_for_permission(DeleteObjects, patient)
+    []
+
+Inactive clients should be still listed for the same roles:
+
+    >>> get_roles_for_permission(ListFolderContents, patient)
+    ['ClientGuest', 'LabClerk', 'LabManager', 'Manager', 'Owner']
+
+No modifications are allowed for inactive patients:
+
+    >>> get_roles_for_permission(ModifyPortalContent, patient)
+    []
+
+Viewing an inactive client is still possible for the same roles
+
+    >>> get_roles_for_permission(View, patient)
+    ['ClientGuest', 'LabClerk', 'LabManager', 'Manager', 'Owner']
+
 
 Field permission in **inactive** state:
 

--- a/src/senaite/patient/tests/doctests/PatientWorkflow.rst
+++ b/src/senaite/patient/tests/doctests/PatientWorkflow.rst
@@ -88,7 +88,7 @@ Global add permission:
 
     >>> from senaite.patient.permissions import AddPatient
     >>> get_roles_for_permission(AddPatient, patients)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
 
 Patient Permissions

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -224,14 +224,16 @@ def update_patient_workflows(tool):
     """
     logger.info("Update patient workflows ...")
 
-    # import workflows
+    # import rolemap, workflow and typeinfo
     portal = tool.aq_inner.aq_parent
     setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "rolemap")
     setup.runImportStepFromProfile(profile, "workflow")
-    wf_tool = api.get_tool("portal_workflow")
+    setup.runImportStepFromProfile(profile, "typeinfo")
 
     # get patient folder + workflow
     patientsfolder = portal.patients
+    wf_tool = api.get_tool("portal_workflow")
     patients_workflow = wf_tool.getWorkflowById(PATIENT_FOLDER_WORKFLOW)
 
     # update rolemappings + object security for patients folder

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -219,6 +219,7 @@ def allow_patients_in_clients(tool):
     logger.info("Allow patients in clients [DONE]")
 
 
+@upgradestep(PRODUCT_NAME, version)
 def update_patient_workflows(tool):
     """Update patient workflows and security settings
     """

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -19,18 +19,21 @@
 # Some rights reserved, see README and LICENSE.
 
 import transaction
-
 from bika.lims import api
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.patient import logger
 from senaite.patient.api import patient_search
+from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.config import PRODUCT_NAME
 from senaite.patient.setuphandlers import setup_catalogs
 
 version = "1.4.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)
+
+PATIENT_WORKFLOW = "senaite_patient_workflow"
+PATIENT_FOLDER_WORKFLOW = "senaite_patient_folder_workflow"
 
 
 @upgradestep(PRODUCT_NAME, version)
@@ -214,3 +217,47 @@ def allow_patients_in_clients(tool):
     setup.runImportStepFromProfile(profile, "plone.app.registry")
 
     logger.info("Allow patients in clients [DONE]")
+
+
+def update_patient_workflows(tool):
+    """Update patient workflows and security settings
+    """
+    logger.info("Update patient workflows ...")
+
+    # import workflows
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "workflow")
+    wf_tool = api.get_tool("portal_workflow")
+
+    # get patient folder + workflow
+    patientsfolder = portal.patients
+    patients_workflow = wf_tool.getWorkflowById(PATIENT_FOLDER_WORKFLOW)
+
+    # update rolemappings + object security for patients folder
+    patients_workflow.updateRoleMappingsFor(patientsfolder)
+    patientsfolder.reindexObject(idxs=["allowedRolesAndUsers"])
+
+    # fetch patients + workflow
+    patients = api.search({"portal_type": "Patient"}, PATIENT_CATALOG)
+    total = len(patients)
+    patient_workflow = wf_tool.getWorkflowById(PATIENT_WORKFLOW)
+
+    for num, patient in enumerate(patients):
+        obj = api.get_object(patient)
+        logger.info("Processing patient %s/%s: %s"
+                    % (num+1, total, obj.Title()))
+
+        # update rolemappings + object security for patient
+        patient_workflow.updateRoleMappingsFor(obj)
+        obj.reindexObject(idxs=["allowedRolesAndUsers"])
+
+        if num and num % 10 == 0:
+            logger.info("Commiting patient %s/%s" % (num+1, total))
+            transaction.commit()
+            logger.info("Commit done")
+
+        # Flush the object from memory
+        obj._p_deactivate()
+
+    logger.info("Update patient workflows [DONE]")

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,6 +2,15 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- 1408: Patients inside clients -->
+  <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Update Patient Workflows"
+      description="Update the patient workflows and permission mappings"
+      source="1407"
+      destination="1408"
+      handler="senaite.patient.upgrade.v01_04_000.update_patient_workflows"
+      profile="senaite.patient:default"/>
+
   <!-- 1407: Patients inside clients -->
   <genericsetup:upgradeStep
       title="SENAITE PATIENT 1.4.0: Allow patients in clients"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**☝️ Please merge #68 first**

This PR fixes the Patient Workflows to hide the global patent folder and the contained patients from client contact users.

## Current behavior before PR

Basically all logged in users could view the global patients folder and select any patient for their samples.

## Desired behavior after PR is merged

Patient folder can be only seen by the following roles: `LabManager`, `Manager`, `LabClerk`.
These roles can also create new patients.

If client local patients are enabled, the `Owner` roles can View/Edit local patients as well.

The `ClientGuest` role can only view, but not edit shared patients. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
