### PR TITLE
Migrate sample's DateOfBirth field to AgeDateOfBirthField

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #74 Migrate sample's DateOfBirth field to AgeDateOfBirthField
 - #72 Move Patient ID to identifiers
 - #69 Fix Patient Workflows and Permissions
 - #68 Allow client local patients

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import re
+from bika.lims import deprecated
 from datetime import datetime
 
 from bika.lims import api
@@ -187,6 +188,7 @@ def update_patient(patient, **values):
     patient.reindexObject()
 
 
+@deprecated("Us senaite.core.api.dtime.to_dt instead")
 def to_datetime(date_value, default=None, tzinfo=None):
     if isinstance(date_value, datetime):
         return date_value
@@ -256,7 +258,7 @@ def get_birth_date(age_ymd, on_date=None, default=_marker):
             raise AttributeError("No valid ymd: {}".format(age_ymd))
         return default
 
-    on_date = to_datetime(on_date, default=datetime.now())
+    on_date = dtime.to_dt(on_date) or datetime.now()
     dob = on_date - relativedelta(years=years, months=months, days=days)
     return dob
 
@@ -268,20 +270,12 @@ def get_age_ymd(birth_date, on_date=None):
     return to_ymd(delta)
 
 
+@deprecated("Use senaite.core.api.dtime.get_relative_delta instead")
 def get_relative_delta(from_date, to_date=None):
     """Returns the relative delta between two dates. If to_date is None,
     compares the from_date with now
     """
-    from_date = to_datetime(from_date)
-    if not from_date:
-        raise TypeError("Type not supported: from_date")
-
-    to_date = to_date or datetime.now()
-    to_date = to_datetime(to_date)
-    if not to_date:
-        raise TypeError("Type not supported: to_date")
-
-    return relativedelta(to_date, from_date)
+    return dtime.get_relative_delta(from_date, to_date)
 
 
 def tuplify_identifiers(identifiers):

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -212,7 +212,7 @@ def to_ymd(val, default=_marker):
         if is_ymd(val):
             return val
         if default is _marker:
-            raise TypeError("delta parameter must be a relative_delta")
+            raise TypeError("delta parameter must be a relative_delta or ymd")
         return default
 
     ymd = list("ymd")
@@ -266,8 +266,11 @@ def get_birth_date(age_ymd, on_date=None, default=_marker):
 def get_age_ymd(birth_date, on_date=None):
     """Returns the age at on_date if not None. Otherwise, current age
     """
-    delta = dtime.get_relative_delta(birth_date, on_date)
-    return to_ymd(delta)
+    try:
+        delta = dtime.get_relative_delta(birth_date, on_date)
+        return to_ymd(delta)
+    except (ValueError, TypeError):
+        return None
 
 
 @deprecated("Use senaite.core.api.dtime.get_relative_delta instead")

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -228,22 +228,22 @@ def is_ymd(ymd):
     return values is not None
 
 
-def get_years_months_days(ymd, default=_marker):
-    """Returns a tuple of (years, month, days)
+def get_years_months_days(ymd):
+    """Returns a tuple of (years, months, days) given a period in ymd format.
+
+    Returns (0, 0, 0) if not possible to extract the years, months and days
+    from the given ymd.
+
+    :param ymd: period in ymd format
+    :type ymd: str
+    :returns: a tuple with the years, months and days
+    :rtype: tuple
     """
     def extract_period(val, period):
         num = re.findall(r'(\d{1,2})'+period, str(val)) or [0]
         return api.to_int(num[0], default=0)
 
-    years = extract_period(ymd, "y")
-    months = extract_period(ymd, "m")
-    days = extract_period(ymd, "d")
-    if not any([years, months, days]):
-        if default is _marker:
-            raise AttributeError("No valid ymd: {}".format(ymd))
-        return default
-
-    return years, months, days
+    return tuple([extract_period(ymd, part) for part in "ymd"])
 
 
 def get_birth_date(age_ymd, on_date=None, default=_marker):

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -49,9 +49,9 @@ CLIENT_VIEW_ACTION = {
     "condition": "",
 }
 
-YMD_REGEX = r'^((?P<y>(\d{1,4}))y){0,1}\s*' \
-            r'((?P<m>(\d{1,2}))m){0,1}\s*' \
-            r'((?P<d>(\d{1,2}))d){0,1}\s*'
+YMD_REGEX = r'^((?P<y>(\d+))y){0,1}\s*' \
+            r'((?P<m>(\d+))m){0,1}\s*' \
+            r'((?P<d>(\d+))d){0,1}\s*'
 
 _marker = object()
 
@@ -274,32 +274,25 @@ def get_years_months_days(period):
 
     # extract the years, months and days
     matches = re.search(YMD_REGEX, raw_ymd)
-    values = [matches.group(period) for period in "ymd"]
+    values = [matches.group(v) for v in "ymd"]
 
     # if all values are None, assume the ymd format was not valid
     nones = [value is None for value in values]
     if all(nones):
         raise ValueError("Not a valid ymd: {}".format(repr(period)))
 
-    # replace Nones with zeros
+    # replace Nones with zeros and calculate everything with a relativedelta
     values = [api.to_int(value, 0) for value in values]
-    return values
+    delta = relativedelta(years=values[0], months=values[1], days=values[2])
+    return get_years_months_days(delta)
 
 
-@deprecated("Use get_since_date instead")
-def get_birth_date(ymd, on_date=None, default=_marker):
-    """Returns the birth date given an age in ymd format and the date when age
-    was recorded or current datetime if None
-    """
-    return get_since_date(ymd, on_date=on_date, default=default)
-
-
-def get_since_date(period, on_date=None, default=_marker):
+def get_birth_date(period, on_date=None, default=_marker):
     """Returns the date when something started given a period in ymd format
     and the date when such period was recorded
 
     If on_date is None, uses current date time as the date from which the
-    since date is calculated.
+    birth date is calculated.
 
     When ymd is not a valid period and default value is _marker, a TypeError
     or ValueError is raised. Otherwise, it returns the default value converted

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -259,12 +259,18 @@ def get_years_months_days(period):
     from the given period.
 
     :param period: period of time
-    :type period: str/relativedelta
+    :type period: str/relativedelta/tuple/list
     :returns: a tuple with the years, months and days
     :rtype: tuple
     """
     if isinstance(period, relativedelta):
         return period.years, period.months, period.days
+
+    if isinstance(period, (tuple, list)):
+        years = api.to_int(period[0], default=0)
+        months = api.to_int(period[1] if len(period) > 1 else 0, default=0)
+        days = api.to_int(period[2] if len(period) > 2 else 0, default=0)
+        return years, months, days
 
     if not isinstance(period, string_types):
         raise TypeError("{} is not supported".format(repr(period)))

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -188,7 +188,7 @@ def update_patient(patient, **values):
     patient.reindexObject()
 
 
-@deprecated("Us senaite.core.api.dtime.to_dt instead")
+@deprecated("Use senaite.core.api.dtime.to_dt instead")
 def to_datetime(date_value, default=None, tzinfo=None):
     if isinstance(date_value, datetime):
         return date_value

--- a/src/senaite/patient/browser/widgets/agedob.py
+++ b/src/senaite/patient/browser/widgets/agedob.py
@@ -34,10 +34,6 @@ class AgeDoBWidget(DateTimeWidget):
                      emptyReturnsMarker=False, validating=True):
         value = form.get(field.getName())
 
-        # Not interested in the hidden field, but in the age + dob specific
-        if isinstance(value, (list, tuple)):
-            value = value[0] or None
-
         # Allow non-required fields
         if not value:
             return None, {}
@@ -85,13 +81,14 @@ class AgeDoBWidget(DateTimeWidget):
                 # "estimated" to change if he/she presses the Save button
                 # without the dob value being changed
                 orig_ansi = dtime.to_ansi(orig_dob, show_time=False)
-                dob_ansi = dob.to_ansi(dob, show_time=False)
+                dob_ansi = dtime.to_ansi(dob, show_time=False)
                 output["estimated"] = orig_ansi != dob_ansi
 
         else:
-            # User entered date of birth, not estimated
             dob = value.get("dob", "")
             output["dob"] = dtime.to_dt(dob)
+            output["from_age"] = value.get("from_age", False)
+            output["estimated"] = value.get("estimated", False)
 
         return output, {}
 

--- a/src/senaite/patient/browser/widgets/agedob.py
+++ b/src/senaite/patient/browser/widgets/agedob.py
@@ -60,8 +60,7 @@ class AgeDoBWidget(DateTimeWidget):
                 return None, {}
 
             # Age in ymd format
-            ymd = filter(lambda p: p[0], zip(ymd, 'ymd'))
-            ymd = "".join(map(lambda p: "".join(p), ymd))
+            ymd = patient_api.to_ymd(ymd)
 
             # Calculate the DoB
             dob = patient_api.get_birth_date(ymd)

--- a/src/senaite/patient/content/analysisrequest.py
+++ b/src/senaite/patient/content/analysisrequest.py
@@ -25,7 +25,6 @@ from bika.lims.browser.widgets import SelectionWidget
 from bika.lims.interfaces import IAnalysisRequest
 from Products.Archetypes.Widget import TextAreaWidget
 from Products.CMFCore.permissions import View
-from senaite.core.browser.widgets import QuerySelectWidget
 from senaite.patient import messageFactory as _
 from senaite.patient.api import get_patient_name_entry_mode
 from senaite.patient.api import is_age_supported
@@ -36,9 +35,9 @@ from senaite.patient.browser.widgets import TemporaryIdentifierWidget
 from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.config import GENDERS
 from senaite.patient.config import SEXES
-from senaite.patient.content import ExtDateTimeField
 from senaite.patient.content import ExtStringField
 from senaite.patient.content import ExtTextField
+from senaite.patient.content.fields import AgeDateOfBirthField
 from senaite.patient.content.fields import FullnameField
 from senaite.patient.content.fields import TemporaryIdentifierField
 from senaite.patient.interfaces import ISenaitePatientLayer
@@ -142,7 +141,7 @@ PatientAddressField = ExtTextField(
     )
 )
 
-DateOfBirthField = ExtDateTimeField(
+dob_field = AgeDateOfBirthField(
     "DateOfBirth",
     required=False,
     read_permission=View,
@@ -210,7 +209,7 @@ class AnalysisRequestSchemaExtender(object):
             MedicalRecordNumberField,
             PatientFullNameField,
             PatientAddressField,
-            DateOfBirthField,
+            dob_field,
             SexField,
             GenderField,
         ]

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -184,13 +184,19 @@ class AgeDateOfBirthField(ExtensionField, ObjectField):
         """Returns the age in ymd format at on_date or current date
         """
         age = self.get_age(instance, on_date=on_date)
-        return patient_api.to_ymd(age, default=None)
+        try:
+            return patient_api.to_ymd(age, default=None)
+        except TypeError:
+            return None
 
     def get_age(self, instance, on_date=None):
         """Returns the age as a relative delta at on_date or current data
         """
         dob = self.get_date_of_birth(instance)
-        return dtime.get_relative_delta(dob, on_date)
+        try:
+            return dtime.get_relative_delta(dob, on_date)
+        except ValueError:
+            return None
 
     def get_from_age(self, instance):
         """Returns whether the date of birth is calculated from age

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -175,33 +175,22 @@ class AgeDateOfBirthField(ExtensionField, ObjectField):
         val = (dob, from_age, estimated) if dob else self.getDefault(instance)
         super(AgeDateOfBirthField, self).set(instance, val)
 
-    def get(self, instance, **kwargs):
-        val = super(AgeDateOfBirthField, self).get(instance, **kwargs)
-        if dtime.is_date(val):
-            dob = dtime.to_dt(val)
-            return (
-                dob,
-                getattr(instance, "_AgeDoBWidget_age_selected", False),
-                getattr(instance, "_AgeDoBWidget_dob_estimated", False)
-            )
-        return val
-
     def get_date_of_birth(self, instance):
         """Returns whether the date of birth
         """
         return self.get(instance)[:][0]
 
-    def get_ymd(self, instance):
-        """Returns the age in ymd format at current date
+    def get_age_ymd(self, instance, on_date=None):
+        """Returns the age in ymd format at on_date or current date
         """
-        dob = self.get_date_of_birth(instance)
-        return patient_api.get_age_ymd(dob)
+        age = self.get_age(instance, on_date=on_date)
+        return patient_api.to_ymd(age, default=None)
 
-    def get_age(self, instance):
-        """Returns the age as a relative delta at current date
+    def get_age(self, instance, on_date=None):
+        """Returns the age as a relative delta at on_date or current data
         """
         dob = self.get_date_of_birth(instance)
-        return dtime.get_relative_delta(dob)
+        return dtime.get_relative_delta(dob, on_date)
 
     def get_from_age(self, instance):
         """Returns whether the date of birth is calculated from age

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -186,10 +186,7 @@ class AgeDateOfBirthField(ExtensionField, ObjectField):
         """Returns the age in ymd format at on_date or current date
         """
         age = self.get_age(instance, on_date=on_date)
-        try:
-            return patient_api.to_ymd(age, default=None)
-        except TypeError:
-            return None
+        return patient_api.to_ymd(age, default=None)
 
     def get_age(self, instance, on_date=None):
         """Returns the age as a relative delta at on_date or current data

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -159,7 +159,10 @@ class AgeDateOfBirthField(ExtensionField, ObjectField):
             if not dob:
                 age = value.get("age")
                 dob = patient_api.get_birth_date(age, default=None)
+                # DoB is inferred from age, so it must be estimated,
+                # regardless of what is coming with the dict
                 from_age = dob is not None
+                estimated = dob is not None
 
         elif dtime.is_date(value):
             dob = dtime.to_dt(value)
@@ -168,8 +171,7 @@ class AgeDateOfBirthField(ExtensionField, ObjectField):
 
         elif patient_api.is_ymd(value):
             dob = patient_api.get_birth_date(value)
-            estimated = is_true(kwargs.get("estimated", False))
-            from_age = True
+            from_age = estimated = True
 
         # store the tuple or default
         val = (dob, from_age, estimated) if dob else self.getDefault(instance)

--- a/src/senaite/patient/monkeys/configure.zcml
+++ b/src/senaite/patient/monkeys/configure.zcml
@@ -51,11 +51,17 @@
 
   <!-- Patient Date of Birth -->
   <monkey:patch
-    description="Patient's date of birth"
+    description="Patient's date of birth or age"
     class="bika.lims.content.analysisrequest.AnalysisRequest"
     original="getDateOfBirth"
     ignoreOriginal="True"
     replacement=".content.analysisrequest.getDateOfBirth" />
+  <monkey:patch
+      description="Patient's date of birth or age"
+      class="bika.lims.content.analysisrequest.AnalysisRequest"
+      original="setDateOfBirth"
+      ignoreOriginal="True"
+      replacement=".content.analysisrequest.setDateOfBirth" />
 
   <!-- Patient Age -->
   <monkey:patch

--- a/src/senaite/patient/monkeys/configure.zcml
+++ b/src/senaite/patient/monkeys/configure.zcml
@@ -56,12 +56,27 @@
     original="getDateOfBirth"
     ignoreOriginal="True"
     replacement=".content.analysisrequest.getDateOfBirth" />
+
   <monkey:patch
       description="Patient's date of birth or age"
       class="bika.lims.content.analysisrequest.AnalysisRequest"
       original="setDateOfBirth"
       ignoreOriginal="True"
       replacement=".content.analysisrequest.setDateOfBirth" />
+
+  <monkey:patch
+      description="Whether patient's date of birth is estimated"
+      class="bika.lims.content.analysisrequest.AnalysisRequest"
+      original="getDateOfBirthEstimated"
+      ignoreOriginal="True"
+      replacement=".content.analysisrequest.getDateOfBirthEstimated" />
+
+  <monkey:patch
+      description="Whether patient's date of birth was inferred from age"
+      class="bika.lims.content.analysisrequest.AnalysisRequest"
+      original="getDateOfBirthFromAge"
+      ignoreOriginal="True"
+      replacement=".content.analysisrequest.getDateOfBirthFromAge" />
 
   <!-- Patient Age -->
   <monkey:patch
@@ -70,6 +85,14 @@
     original="getAge"
     ignoreOriginal="True"
     replacement=".content.analysisrequest.getAge" />
+
+  <!-- Patient Age in ymd format -->
+  <monkey:patch
+      description="Patient's age in ymd format"
+      class="bika.lims.content.analysisrequest.AnalysisRequest"
+      original="getAgeYmd"
+      ignoreOriginal="True"
+      replacement=".content.analysisrequest.getAgeYmd" />
 
   <!-- Patient Address -->
   <monkey:patch

--- a/src/senaite/patient/monkeys/content/analysisrequest.py
+++ b/src/senaite/patient/monkeys/content/analysisrequest.py
@@ -85,9 +85,9 @@ def getDateOfBirth(self):  # noqa camelcase
 def getAge(self):  # noqa camelcase
     """Returns the patient's age when the sample was collected
     """
-    dob = self.getDateOfBirth()
+    field = self.getField("DateOfBirth")
     sampled = self.getDateSampled()
-    return get_age_ymd(dob, sampled)
+    return field.get_age_ymd(self, on_date=sampled)
 
 
 @check_installed(None)

--- a/src/senaite/patient/monkeys/content/analysisrequest.py
+++ b/src/senaite/patient/monkeys/content/analysisrequest.py
@@ -93,7 +93,32 @@ def getAge(self):  # noqa camelcase
     """
     field = self.getField("DateOfBirth")
     sampled = self.getDateSampled()
+    return field.get_age(self, on_date=sampled)
+
+
+@check_installed(None)
+def getAgeYmd(self):  # noqa camelcase
+    """Returns the patient's age when the sample was collected in ymd format
+    """
+    field = self.getField("DateOfBirth")
+    sampled = self.getDateSampled()
     return field.get_age_ymd(self, on_date=sampled)
+
+
+@check_installed(None)
+def getDateOfBirthEstimated(self):  # noqa camelcase
+    """Returns whether the date of birth is estimated
+    """
+    field = self.getField("DateOfBirth")
+    return field.get_estimated(self)
+
+
+@check_installed(None)
+def getDateOfBirthFromAge(self):  # noqa camelcase
+    """Returns whether the date of birth was inferred from age
+    """
+    field = self.getField("DateOfBirth")
+    return field.get_from_age(self)
 
 
 @check_installed(None)

--- a/src/senaite/patient/monkeys/content/analysisrequest.py
+++ b/src/senaite/patient/monkeys/content/analysisrequest.py
@@ -81,6 +81,13 @@ def getDateOfBirth(self):  # noqa camelcase
 
 
 @check_installed(None)
+def setDateOfBirth(self, value):  # noqa camelcase
+    """Sets the date of birth or age to sample's patient
+    """
+    return self.getField("DateOfBirth").set(self, value)
+
+
+@check_installed(None)
 def getAge(self):  # noqa camelcase
     """Returns the patient's age when the sample was collected
     """

--- a/src/senaite/patient/monkeys/content/analysisrequest.py
+++ b/src/senaite/patient/monkeys/content/analysisrequest.py
@@ -19,7 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 from senaite.patient import check_installed
-from senaite.patient.api import get_age_ymd
 
 
 @check_installed(False)

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1410</version>
+  <version>1411</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -177,7 +177,7 @@
                  'onchange' is not triggered for hidden fields -->
             <input type="text" style="display:none;visibility:hidden;"
                    tal:attributes="id string:${fieldName}-dob-fallback;
-                         name string:${fieldName};
+                         name string:${fieldName}-dob-fallback:record;
                          value string:${value}"/>
           </div>
         </div>

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -8,31 +8,33 @@
 
     <metal:view_macro define-macro="view">
       <span metal:define-slot="inside"
-            tal:define="value accessor;
-                        dob_estimated python:widget.get_dob_estimated(context);
-                        current_age python:widget.get_current_age(value);
-                        years python:current_age.get('years') or '';
-                        months python:current_age.get('months') or '';
-                        days python:current_age.get('days') or '';
-                        value python: widget.ulocalized_time(value, context=context, request=request) if value else ''">
+            tal:define="values python:field.getAccessor(here)();
+                        dob python: values[0];
+                        age_selected python: values[1];
+                        dob_estimated python: values[2];
+                        current_age python:field.get_age(here);
+                        years python:current_age.years if current_age else '';
+                        months python:current_age.months if current_age else '';
+                        days python:current_age.days if current_age else '';
+                        value python: widget.ulocalized_time(dob, context=here, request=request) if dob else ''">
 
         <!-- Date of birth -->
         <span tal:condition="python:not dob_estimated">
-          <span tal:replace="value"></span>
+          <span tal:replace="value"/>
         </span>
 
         <!-- Age (estimated) -->
         <span class="" tal:condition="python:dob_estimated">
           <span tal:condition="python:years">
-            <span tal:replace="years"></span>
+            <span tal:replace="years"/>
             <span class="text-secondary" i18n:translate="patient_dob_years">Years</span>
           </span>
           <span tal:condition="python:months">
-            <span tal:replace="months"></span>
+            <span tal:replace="months"/>
             <span class="text-secondary" i18n:translate="patient_dob_months">Months</span>
           </span>
           <span tal:condition="python:days">
-            <span tal:replace="days"></span>
+            <span tal:replace="days"/>
             <span class="text-secondary" i18n:translate="patient_dob_days">Days</span>
           </span>
         </span>
@@ -41,7 +43,13 @@
     </metal:view_macro>
 
     <metal:edit_macro define-macro="edit">
-      <tal:values define="value python:field.getEditAccessor(here)() or None;
+      <tal:values define="values python:field.getEditAccessor(here)();
+                          session_values python:here.session_restore_value(fieldName, values);
+                          cached_values python:request.get(fieldName,session_values);
+                          values python:cached_values or values;
+                          dob python: values[0];
+                          age_selected python: values[1];
+                          dob_estimated python: values[2];
                           subfield_years string:${fieldName}.years:ignore_empty:record;
                           subfield_months string:${fieldName}.months:ignore_empty:record;
                           subfield_days string:${fieldName}.days:ignore_empty:record;
@@ -49,14 +57,13 @@
                           subfield_selector string:${fieldName}.selector:ignore_empty:record;
                           subfield_original_value string:${fieldName}.original:ignore_empty:record;
                           required field/required|nothing;
-                          current_age python:widget.get_current_age(value);
-                          years python:current_age.get('years') or '';
-                          months python:current_age.get('months') or '';
-                          days python:current_age.get('days') or '';
-                          age_selected python:widget.get_age_selected(context);
-                          age_supported python:widget.is_age_supported(context);
-                          dob_estimated python:widget.get_dob_estimated(context);
-                          years_only python:widget.is_years_only(value);
+                          current_age python:field.get_age(here);
+                          years python:current_age.years if current_age else '';
+                          months python:current_age.months if current_age else '';
+                          days python:current_age.days if current_age else '';
+                          age_supported python:widget.is_age_supported();
+                          years_only python:widget.is_years_only();
+                          years_only python:years_only and years and years >= 1;
                           show_months python:not years_only;
                           show_days python:not years_only;">
 
@@ -138,7 +145,8 @@
 
           <!-- DoB input field -->
           <div tal:attributes="id string:${fieldName}_dob_controls;
-                               style python:'display:none' if age_selected else ''">
+                               style python:'display:none' if age_selected else ''"
+               tal:define="value python: widget.get_date(dob) if dob else ''">
             <div class="input-group input-group-sm flex-nowrap d-inline-flex w-auto">
               <input type="date"
                      style="min-width:130px;max-width:130px"
@@ -147,7 +155,7 @@
                          id string:${subfield_dob};
                          name string:${subfield_dob};
                          required python:required and 'required' or None;
-                         value python: widget.get_date(value) if value else '';
+                         value python: value;
                          class python: 'form-control form-control-sm {}'.format(invalid_class);"/>
 
               <div tal:condition="dob_estimated"

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -59,15 +59,6 @@ def on_object_created(instance, event):
 def on_object_edited(instance, event):
     """Event handler when a sample was edited
     """
-    # XXX "save" from Sample's header view does not call widget's process_form
-    request = api.get_request()
-    field_name = "DateOfBirth"
-    if field_name in request.form:
-        dob_field = instance.getField(field_name)
-        dob = dob_field.widget.process_form(instance, dob_field, request.form)
-        if dob is not None:
-            dob_field.set(instance, dob[0])
-
     update_patient(instance)
 
 

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -155,7 +155,7 @@ def get_patient_fields(instance):
         "mrn": mrn,
         "sex": sex,
         "gender": gender,
-        "birthdate": birthdate,
+        "birthdate": birthdate[0],
         "address": address,
         "firstname": api.safe_unicode(firstname),
         "middlename": api.safe_unicode(middlename),

--- a/src/senaite/patient/tests/doctests/API.rst
+++ b/src/senaite/patient/tests/doctests/API.rst
@@ -1,0 +1,202 @@
+Patient's API
+-------------
+
+SENAITE Patient's API provides commonly used functions
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t API
+
+Needed Imports:
+
+    >>> from datetime import date
+    >>> from dateutil.relativedelta import relativedelta
+    >>> from senaite.core.api import dtime
+    >>> from senaite.patient import api
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+
+
+Convert a period to ymd format
+..............................
+
+We can convert a relativedelta to ymd format:
+
+    >>> period = relativedelta(years=1, months=2, days=3)
+    >>> api.to_ymd(period)
+    '1y 2m 3d'
+
+    >>> period = relativedelta(months=6, days=2)
+    >>> api.to_ymd(period)
+    '6m 2d'
+
+    >>> period = relativedelta()
+    >>> api.to_ymd(period)
+    ''
+
+Or can transform an already existing ymd to its standard format:
+
+    >>> api.to_ymd("1y2m3d")
+    '1y 2m 3d'
+
+Zeros and whitespaces are omitted as well:
+
+    >>> api.to_ymd("1y0m   3d")
+    '1y 3d'
+
+Returns a TypeError if the value is not of the expected type:
+
+    >>> api.to_ymd(object())
+    Traceback (most recent call last):
+    [...]
+    TypeError: <object object at ... is not supported
+
+Returns a ValueError if the value has the rihgt type, but format is wrong:
+
+    >>> api.to_ymd("123")
+    Traceback (most recent call last):
+    [...]
+    ValueError: Not a valid ymd: '123'
+
+    >>> api.to_ymd("y123d")
+    Traceback (most recent call last):
+    [...]
+    ValueError: Not a valid ymd: 'y123d'
+
+Function is even aware of monthly and yearly shifts:
+
+    >>> period = relativedelta(years=1235, months=23, days=10)
+    >>> api.to_ymd(period)
+    '1236y 11m 10d'
+
+    >>> api.to_ymd("1235y23m10d")
+    '1236y 11m 10d'
+
+    >>> api.to_ymd("1235y43m10d")
+    '1238y 7m 10d'
+
+
+Check if a value is a ymd
+.........................
+
+Returns true for ymd-like strings:
+
+    >>> api.is_ymd("3d")
+    True
+
+    >>> api.is_ymd("2m  3d")
+    True
+
+    >>> api.is_ymd("0y 2m3d")
+    True
+
+    >>> api.is_ymd("0y0m0d")
+    True
+
+But returns false if the format or type is not valid:
+
+    >>> api.is_ymd("y3d")
+    False
+
+    >>> api.is_ymd("")
+    False
+
+    >>> api.is_ymd(object())
+    False
+
+    >>> api.is_ymd(relativedelta())
+    False
+
+
+Get the years, months and days from a period
+............................................
+
+We can extract the years, months and days from a period:
+
+    >>> period = relativedelta(years=1, months=2, days=3)
+    >>> api.get_years_months_days(period)
+    (1, 2, 3)
+
+    >>> period = relativedelta(months=6, days=2)
+    >>> api.get_years_months_days(period)
+    (0, 6, 2)
+
+    >>> period = relativedelta()
+    >>> api.get_years_months_days(period)
+    (0, 0, 0)
+
+Periods in ymd format are supported as well:
+
+    >>> api.get_years_months_days("1y2m3d")
+    (1, 2, 3)
+
+    >>> api.get_years_months_days("1y0m   3d")
+    (1, 0, 3)
+
+Returns a TypeError if the value is not of the expected type:
+
+    >>> api.get_years_months_days(object())
+    Traceback (most recent call last):
+    [...]
+    TypeError: <object object at ... is not supported
+
+Returns a ValueError if the value has the rihgt type, but format is wrong:
+
+    >>> api.get_years_months_days("123")
+    Traceback (most recent call last):
+    [...]
+    ValueError: Not a valid ymd: '123'
+
+    >>> api.get_years_months_days("y123d")
+    Traceback (most recent call last):
+    [...]
+    ValueError: Not a valid ymd: 'y123d'
+
+Function is even aware of monthly and yearly shifts:
+
+    >>> api.get_years_months_days("1235y23m10d")
+    (1236, 11, 10)
+
+    >>> api.get_years_months_days("1235y43m10d")
+    (1238, 7, 10)
+
+
+Get the birth date
+..................
+
+Having a period, the function returns the date when the event happened relative
+to the current date:
+
+    >>> dob = api.get_birth_date("10y1m1d")
+    >>> expected = date.today() - relativedelta(years=10, months=1, days=1)
+    >>> dtime.to_ansi(dob, False) == dtime.to_ansi(expected, False)
+    True
+
+We can also get the birth date having an age and the date when the age was
+recorded:
+
+    >>> delta = relativedelta(years=5, months=5)
+    >>> on_date = date.today() - delta
+    >>> dob = api.get_birth_date("10y1m1d", on_date=on_date)
+    >>> expected = on_date - relativedelta(years=10, months=1, days=1)
+    >>> dtime.to_ansi(dob, False) == dtime.to_ansi(expected, False)
+    True
+
+
+Get the age
+...........
+
+Having a birth date, we can get the age at a given date:
+
+    >>> dob = dtime.to_dt("19791207")
+    >>> api.get_age_ymd(dob, on_date="20230518")
+    '43y 5m 11d'
+
+If we don't provide an `on_date`, system uses current date:
+
+    >>> ymd = api.get_age_ymd(dob)
+    >>> ymd == api.get_age_ymd(dob, on_date=date.today())
+    True

--- a/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
+++ b/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
@@ -1,0 +1,141 @@
+AgeDateOfBirthField
+-------------------
+
+AgeDateOfBirthField is a field that allows to store the datetime when something
+was born, but with support for age and estimated.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t AgeDateOfBirthField
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from DateTime import DateTime
+    >>> from datetime import datetime
+    >>> from senaite.core.api import dtime
+    >>> from senaite.patient.api import to_ymd
+
+Functional Helpers:
+
+    >>> def new_sample(services, client, contact, sample_type, date_sampled, **kw):
+    ...     values = {
+    ...         'Client': api.get_uid(client),
+    ...         'Contact': api.get_uid(contact),
+    ...         'DateSampled': date_sampled,
+    ...         'SampleType': api.get_uid(sample_type)}
+    ...     values.update(kw)
+    ...     service_uids = map(api.get_uid, services)
+    ...     sample = create_analysisrequest(client, request, values, service_uids)
+    ...     return sample
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+    >>> sampled = DateTime("2020-12-01")
+    >>> birth_date = DateTime("1979-12-07")
+
+We need to create some basic objects for the test:
+
+    >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Clinical Lab", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)
+    >>> malaria = api.create(setup.bika_analysisservices, "AnalysisService", title="Malaria Count", Keyword="MC", Price="10", Category=category.UID(), Accredited=True)
+    >>> sample = new_sample([malaria], client, contact, sampletype, sampled, DateOfBirth=birth_date)
+
+Get the field:
+
+    >>> field = sample.getField("DateOfBirth")
+    >>> field
+    <Field DateOfBirth(date_of_birth:rw)>
+
+Get the full information returned by the field for the given sample:
+
+    >>> field.get(sample)
+    (datetime.datetime(1979, 12, 7, 0, 0, tzinfo=<StaticTzInfo 'Etc/GMT'>), False, False)
+
+Get the date of birth:
+
+    >>> dob = field.get_date_of_birth(sample)
+    >>> dob
+    datetime.datetime(1979, 12, 7, 0, 0, tzinfo=<StaticTzInfo 'Etc/GMT'>)
+
+Get the age at current time as timedelta:
+
+    >>> agen = dtime.get_relative_delta(dob, datetime.now())
+    >>> age = field.get_age(sample)
+    >>> [agen.years, agen.months, agen.days] == [age.years, age.months, age.days]
+    True
+
+Get the age at current time in ymd format:
+
+    >>> age_now_ymd = to_ymd(agen)
+    >>> age_ymd = field.get_age_ymd(sample)
+    >>> age_now_ymd == age_ymd
+    True
+
+Get the age at the time when the sample was collected:
+
+    >>> field.get_age(sample, sampled)
+    relativedelta(years=+40, months=+11, days=+24)
+
+Get the age at the time when the sample was collected in ymd format:
+
+    >>> field.get_age_ymd(sample, sampled)
+    '40y 11m 24d'
+
+Check if the age was set instead of the date of birth:
+
+    >>> field.get_from_age(sample)
+    False
+
+Check if the date of birth must be considered as estimated:
+
+    >>> field.get_estimated(sample)
+    False
+
+We can set an age instead of a date of birth in ymd format:
+
+    >>> field.set(sample, "43y2m3d")
+    >>> field.get_age_ymd(sample)
+    '43y 2m 3d'
+
+And the date of birth is calculated automatically:
+
+    >>> dob = field.get_date_of_birth(sample)
+    >>> age = field.get_age(sample)
+    >>> elapsed = dob + age
+    >>> now = datetime.now()
+    >>> dtime.to_ansi(elapsed, False) == dtime.to_ansi(now, False)
+    True
+
+And since the birth date does has been inferred and we don't have full
+information about it (like e.g. hours, minutes, timezone, etc.) both
+`estimated` and `from_age` attrs are set to `True`:
+
+    >>> field.get_from_age(sample)
+    True
+
+    >>> field.get_estimated(sample)
+    True
+
+We can even set the values directly on the setter:
+
+    >>> field.set(sample, birth_date, estimated=True)
+    >>> field.get_date_of_birth(sample)
+    datetime.datetime(1979, 12, 7, 0, 0, tzinfo=<StaticTzInfo 'Etc/GMT'>)
+
+    >>> field.get_age_ymd(sample, sampled)
+    '40y 11m 24d'
+
+    >>> field.get_estimated(sample)
+    True
+
+    >>> field.get_from_age(sample)
+    False

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -1,5 +1,5 @@
-Patient Workflow
-----------------
+Patient Sample
+--------------
 
 Running this test from the buildout directory:
 
@@ -22,6 +22,7 @@ Needed Imports:
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_PASSWORD
     >>> from bika.lims.api.security import get_roles_for_permission
+    >>> from senaite.core.api import dtime
     >>> from senaite.patient.api import tuplify_identifiers
     >>> from senaite.patient.api import to_identifier_type_name
 
@@ -95,69 +96,68 @@ Get the patient's full name:
     >>> sample.getPatientFullName()
     'Clark Kent'
 
-Get the patient's date of birth:
+Get the patient's date of birth full information:
 
     >>> sample.getDateOfBirth()
-    ('1980-02-25', False, False)
+    (datetime.datetime(1980, 2, 25, 0, 0, tzinfo=<StaticTzInfo 'Etc/GMT'>), False, False)
 
-Get the patient's age when sample was collected:
+Get the patient's age when sample was collected as timedelta:
 
-    >>> field = sample.getAge()
+    >>> sample.getAge()
+    relativedelta(years=+43, months=+2, days=+21, hours=+22)
 
-Directly get the Date of Birth from the field:
+Get the patient's age when the sample was collected in ymd format:
 
-    >>> dob_field = sample.getField("DateOfBirth")
-    >>> dob_field.get_date_of_birth(sample)
-
-Get the age of the patient at current time:
-
-    >>> dob_field.get_age(sample)
-
-Get the age of the patient when sample was collected using the field:
-
-    >>> dob_field.get_age(sample, sample.getDateSampled())
-
-Get the age in ymd of the patient when sample was collected:
-
-    >>> dob_field.get_age_ymd(sample, sample.getDateSampled())
-
-Check whether the date of birth is estimated:
-
-    >>> dob_field.get_estimated()
-    False
-
-Check whether the date of birth was calculated from age:
-
-    >>> dob_field.get_from_age()
-    False
+    >>> sample.getAgeYmd()
+    '43y 2m 21d'
 
 We can manually set a birth date though, in str/datetime/date format:
 
     >>> sample.setDateOfBirth("1980-01-25")
     >>> sample.getDateOfBirth()
-    ('1980-01-25', False, False)
+    (datetime.datetime(1980, 1, 25, 0, 0, tzinfo=<StaticTzInfo 'Etc/GMT'>), False, False)
 
     >>> sample.setDateOfBirth(DateTime("1980-03-25"))
     >>> sample.getDateOfBirth()
-    ('1980-03-25', False, False)
+    (datetime.datetime(1980, 3, 25, 0, 0, tzinfo=<StaticTzInfo 'Etc/GMT'>), False, False)
 
     >>> from datetime import datetime
     >>> sample.setDateOfBirth(datetime(1980, 4, 25))
     >>> sample.getDateOfBirth()
-    ('1980-04-25', False, False)
+    (datetime.datetime(1980, 4, 25, 0, 0), False, False)
 
-    >>> sample.setDateOfBirth(datetime.date(1980, 4, 25))
+    >>> from datetime import date
+    >>> sample.setDateOfBirth(date(1980, 4, 25))
     >>> sample.getDateOfBirth()
-    ('1980-04-25', False, False)
+    (datetime.datetime(1980, 4, 25, 0, 0), False, False)
+
+And system knows the DoB was directly set as a birth date:
+
+    >>> sample.getDateOfBirthFromAge()
+    False
+
+And that is not estimated:
+
+    >>> sample.getDateOfBirthEstimated()
+    False
 
 Or we can simply set the Birth date with age in ymd format. In such case, the
 system recognizes the date of birth was set from age:
 
-    >>> sample.setDateOfBirth("32y5m")
-    >>> sample.getDateOfBirth()
-    ('1980-04-25', True, False)
+    >>> ymd = sample.getAgeYmd()
+    >>> sample.setDateOfBirth(ymd)
+    >>> dob = sample.getDateOfBirth()
+    >>> dtime.to_ansi(dob[0], show_time=False)
+    '19800426'
 
-    >>> dob_field.get_from_age()
+And system knows the DoB was calculated from Age:
+
+    >>> sample.getDateOfBirthFromAge()
+    True
+
+And also knows it is estimated because of the same reason:
+
+    >>> sample.getDateOfBirthEstimated()
     True
 
 Get the patient's sex:

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -97,8 +97,68 @@ Get the patient's full name:
 
 Get the patient's date of birth:
 
-    >>> sample.getDateOfBirth().strftime("%Y-%m-%d")
-    '1980-02-25'
+    >>> sample.getDateOfBirth()
+    ('1980-02-25', False, False)
+
+Get the patient's age when sample was collected:
+
+    >>> field = sample.getAge()
+
+Directly get the Date of Birth from the field:
+
+    >>> dob_field = sample.getField("DateOfBirth")
+    >>> dob_field.get_date_of_birth(sample)
+
+Get the age of the patient at current time:
+
+    >>> dob_field.get_age(sample)
+
+Get the age of the patient when sample was collected using the field:
+
+    >>> dob_field.get_age(sample, sample.getDateSampled())
+
+Get the age in ymd of the patient when sample was collected:
+
+    >>> dob_field.get_age_ymd(sample, sample.getDateSampled())
+
+Check whether the date of birth is estimated:
+
+    >>> dob_field.get_estimated()
+    False
+
+Check whether the date of birth was calculated from age:
+
+    >>> dob_field.get_from_age()
+    False
+
+We can manually set a birth date though, in str/datetime/date format:
+
+    >>> sample.setDateOfBirth("1980-01-25")
+    >>> sample.getDateOfBirth()
+    ('1980-01-25', False, False)
+
+    >>> sample.setDateOfBirth(DateTime("1980-03-25"))
+    >>> sample.getDateOfBirth()
+    ('1980-03-25', False, False)
+
+    >>> from datetime import datetime
+    >>> sample.setDateOfBirth(datetime(1980, 4, 25))
+    >>> sample.getDateOfBirth()
+    ('1980-04-25', False, False)
+
+    >>> sample.setDateOfBirth(datetime.date(1980, 4, 25))
+    >>> sample.getDateOfBirth()
+    ('1980-04-25', False, False)
+
+Or we can simply set the Birth date with age in ymd format. In such case, the
+system recognizes the date of birth was set from age:
+
+    >>> sample.setDateOfBirth("32y5m")
+    >>> sample.getDateOfBirth()
+    ('1980-04-25', True, False)
+
+    >>> dob_field.get_from_age()
+    True
 
 Get the patient's sex:
 

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -105,12 +105,12 @@ Get the patient's age when sample was collected as timedelta:
 
     >>> age = sample.getAge()
     >>> [age.years, age.months, age.days]
-    [43, 2, 22]
+    [43, 2, 23]
 
 Get the patient's age when the sample was collected in ymd format:
 
     >>> sample.getAgeYmd()
-    '43y 2m 22d'
+    '43y 2m 23d'
 
 We can manually set a birth date though, in str/datetime/date format:
 

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -103,13 +103,14 @@ Get the patient's date of birth full information:
 
 Get the patient's age when sample was collected as timedelta:
 
-    >>> sample.getAge()
-    relativedelta(years=+43, months=+2, days=+21, hours=+22)
+    >>> age = sample.getAge()
+    >>> [age.years, age.months, age.days]
+    [43, 2, 22]
 
 Get the patient's age when the sample was collected in ymd format:
 
     >>> sample.getAgeYmd()
-    '43y 2m 21d'
+    '43y 2m 22d'
 
 We can manually set a birth date though, in str/datetime/date format:
 
@@ -148,7 +149,7 @@ system recognizes the date of birth was set from age:
     >>> sample.setDateOfBirth(ymd)
     >>> dob = sample.getDateOfBirth()
     >>> dtime.to_ansi(dob[0], show_time=False)
-    '19800426'
+    '19800425'
 
 And system knows the DoB was calculated from Age:
 

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,6 +2,15 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- 1411: Migrate sample's DateOfBirth field to AgeDateOfBirthField -->
+  <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Migrate sample's DateOfBirth field"
+      description="Migrate sample's DateOfBirth field to AgeDateOfBirthField"
+      source="1410"
+      destination="1411"
+      handler=".v01_04_000.migrate_date_of_birth_field"
+      profile="senaite.patient:default"/>
+
   <!-- 1410: Remove stale patient ID entries-->
   <genericsetup:upgradeStep
       title="SENAITE PATIENT 1.4.0: Remove stale patient ID catalog entries"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> **Warning**
> Merge https://github.com/senaite/senaite.core/pull/2310 and https://github.com/senaite/senaite.core/pull/2311 first

This Pull Request makes `senaite.patient` compatible with https://github.com/senaite/senaite.core/pull/2307 and https://github.com/senaite/senaite.core/pull/2311 by replacing the `DateTimeField` type for sample's `DateOfBirth` to a new field `AgeDateOfBirthField`, fully supported by the `AgeDoBWidget`.

## Current behavior before PR

The "DateOfBirth" field was only storing the datetime, while other attributes required for the field and widget to work properly were stored as independent attributes in the instance itself.

## Desired behavior after PR is merged

The "DateOfBirth" field stores a tuple (`dob`, `from_age`, `estimated`).

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
