### PR TITLE
Fix tracbeack on DateOfBirth update while validation fails for others

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #76 Fix tracbeack on DateOfBirth update while validation fails for others
 - #74 Migrate sample's DateOfBirth field to AgeDateOfBirthField
 - #72 Move Patient ID to identifiers
 - #70 Ensure Require MRN setting is honoured

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -45,8 +45,7 @@
     <metal:edit_macro define-macro="edit">
       <tal:values define="values python:field.getEditAccessor(here)();
                           session_values python:here.session_restore_value(fieldName, values);
-                          cached_values python:request.get(fieldName,session_values);
-                          values python:cached_values or values;
+                          values python:session_values or values;
                           dob python: values[0];
                           age_selected python: values[1];
                           dob_estimated python: values[2];


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes the traceback that arises for `AgeDoBWidget` when submitting the sample header form and a validator for a field other than `DateOfBirth` fails.

## Current behavior before PR

```
Traceback (most recent call last):
  File "/home/senaite/buildout-cache/eggs/plone.app.viewletmanager-3.1.3-py2.7.egg/plone/app/viewletmanager/manager.py", line 110, in render
    html.append(viewlet.render())
  File "/home/senaite/zinstance/src/senaite.core/src/senaite/core/browser/viewlets/sampleheader.py", line 64, in render
    return self.template(errors=errors)
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 126, in __call__
    return self.__func__(__self__, *args, **kw)
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 61, in __call__
    sourceAnnotations=getattr(debug_flags, 'sourceAnnotations', 0),
  File "/home/senaite/buildout-cache/eggs/zope.pagetemplate-4.6.0-py2.7.egg/zope/pagetemplate/pagetemplate.py", line 135, in pt_render
    strictinsert=0, sourceAnnotations=sourceAnnotations
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/Products/PageTemplates/engine.py", line 378, in __call__
    return template.render(**kwargs)
  File "/home/senaite/buildout-cache/eggs/z3c.pt-3.3.1-py2.7.egg/z3c/pt/pagetemplate.py", line 176, in render
    return base_renderer(**context)
  File "/home/senaite/buildout-cache/eggs/Chameleon-3.9.1-py2.7.egg/chameleon/zpt/template.py", line 302, in render
    return super(PageTemplate, self).render(**_kw)
  File "/home/senaite/buildout-cache/eggs/Chameleon-3.9.1-py2.7.egg/chameleon/template.py", line 215, in render
    raise_with_traceback(exc, tb)
  File "/home/senaite/buildout-cache/eggs/Chameleon-3.9.1-py2.7.egg/chameleon/template.py", line 192, in render
    self._render(stream, econtext, rcontext)
  File "/home/senaite/zinstance/var/my.lims/cache/3b43af95839c40c7434c21391b024f64.py", line 840, in render
    __m(__stream, econtext.copy(), rcontext, __i18n_domain)
  File "/home/senaite/zinstance/var/my.lims/cache/7e99918db1b0c81e3fd3e9de85de5445.py", line 187, in render_edit
    __value = _static_139673307801040('python', u' values[0]', econtext=econtext)(_static_139673307801296(econtext, __zt_tmp))
  File "/home/senaite/buildout-cache/eggs/zope.tales-5.2-py2.7.egg/zope/tales/pythonexpr.py", line 73, in __call__
    return eval(self._code, vars)
  File "<string>", line 1, in <module>
  File "/home/senaite/buildout-cache/eggs/Zope-4.8.7-py2.7.egg/ZPublisher/HTTPRequest.py", line 1798, in __getitem__
    return self.__dict__[key]
KeyError: 0

 - Expression: "dob python: value"
 - Filename:   ... /skins/templates/senaite_patient_widgets/agedobwidget.pt
 - Location:   (line 50: col 26)
 - Source:     dob python: values[0];
               ^^^^^^^^^^^^^^^^^
 - Expression: "python:view.render_widget(field, mode=mode)"
 - Filename:   ... /senaite/core/browser/viewlets/templates/sampleheader.pt
 - Location:   (line 104: col 48)
 - Source:     ... use-macro="python:view.render_widget(field, mode=mode)"/>
```

## Desired behavior after PR is merged

No complains

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
