### PR TITLE
Use system's default timezone for TZ-naive birth dates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #77 Use system's default timezone for TZ-naive birth dates
 - #74 Migrate sample's DateOfBirth field to AgeDateOfBirthField
 - #72 Move Patient ID to identifiers
 - #70 Ensure Require MRN setting is honoured

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -173,6 +173,11 @@ class AgeDateOfBirthField(ExtensionField, ObjectField):
             dob = patient_api.get_birth_date(value)
             from_age = estimated = True
 
+        # if naive TZ, use system default's
+        if dob and dtime.is_timezone_naive(dob):
+            tz = dtime.get_os_timezone()
+            dob = dtime.to_zone(dob, tz)
+
         # store the tuple or default
         val = (dob, from_age, estimated) if dob else self.getDefault(instance)
         super(AgeDateOfBirthField, self).set(instance, val)

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1411</version>
+  <version>1412</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/tests/doctests/API.rst
+++ b/src/senaite/patient/tests/doctests/API.rst
@@ -20,6 +20,12 @@ Variables:
     >>> request = self.request
 
 
+Test fixture:
+
+    >>> import os
+    >>> os.environ["TZ"] = "CET"
+
+
 Convert a period to ymd format
 ..............................
 

--- a/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
+++ b/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
@@ -38,6 +38,11 @@ Variables:
     >>> sampled = DateTime("2020-12-01")
     >>> birth_date = DateTime("1979-12-07")
 
+Test fixture:
+
+    >>> import os
+    >>> os.environ["TZ"] = "CET"
+
 We need to create some basic objects for the test:
 
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -110,12 +110,12 @@ Get the patient's age when sample was collected as timedelta:
 
     >>> age = sample.getAge()
     >>> [age.years, age.months, age.days]
-    [43, 2, 23]
+    [43, 2, 24]
 
 Get the patient's age when the sample was collected in ymd format:
 
     >>> sample.getAgeYmd()
-    '43y 2m 23d'
+    '43y 2m 24d'
 
 We can manually set a birth date though, in str/datetime/date format:
 

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -59,6 +59,11 @@ Variables:
     >>> patients = portal.patients
     >>> birthdate = DateTime("1980-02-25")
 
+Test fixture:
+
+    >>> import os
+    >>> os.environ["TZ"] = "CET"
+
 We need to create some basic objects for the test:
 
     >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
@@ -125,12 +130,12 @@ We can manually set a birth date though, in str/datetime/date format:
     >>> from datetime import datetime
     >>> sample.setDateOfBirth(datetime(1980, 4, 25))
     >>> sample.getDateOfBirth()
-    (datetime.datetime(1980, 4, 25, 0, 0), False, False)
+    (datetime.datetime(1980, 4, 25, 0, 0, tzinfo=<DstTzInfo 'CET' CEST+2:00:00 DST>), False, False)
 
     >>> from datetime import date
     >>> sample.setDateOfBirth(date(1980, 4, 25))
     >>> sample.getDateOfBirth()
-    (datetime.datetime(1980, 4, 25, 0, 0), False, False)
+    (datetime.datetime(1980, 4, 25, 0, 0, tzinfo=<DstTzInfo 'CET' CEST+2:00:00 DST>), False, False)
 
 And system knows the DoB was directly set as a birth date:
 

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -4,6 +4,15 @@
 
   <!-- 1411: Migrate sample's DateOfBirth field to AgeDateOfBirthField -->
   <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Use System's TZ to store Dates of birth that are TZ-naive"
+      description="Use System's TZ to store Dates of birth that are timezone-naive"
+      source="1411"
+      destination="1412"
+      handler=".v01_04_000.update_naive_tz_dobs"
+      profile="senaite.patient:default"/>
+
+  <!-- 1411: Migrate sample's DateOfBirth field to AgeDateOfBirthField -->
+  <genericsetup:upgradeStep
       title="SENAITE PATIENT 1.4.0: Migrate sample's DateOfBirth field"
       description="Migrate sample's DateOfBirth field to AgeDateOfBirthField"
       source="1410"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to automatically assign the OS's timezone to the Date of Birth if it is TZ-naive. This is especially important to guarantee that there are no inconsistencies when calculating age (that may cause an _inexplicable_ shift of 1d), amongst other reasons.

In addition, this makes the tests pass everywhere, regardless of the location of the machine running the tests.

## Current behavior before PR

Dates of birth that are timezone-naive are stored as-is

## Desired behavior after PR is merged

Current OS' TZ is used for when storeing Dates of birth that are TZ-naive

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
