### PR TITLE
Make `to_ymd` return a compliant ymd when no elapsed days

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #78 Make to_ymd return a compliant ymd when no elapsed days
 - #74 Migrate sample's DateOfBirth field to AgeDateOfBirthField
 - #72 Move Patient ID to identifiers
 - #70 Ensure Require MRN setting is honoured

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -232,7 +232,10 @@ def to_ymd(period, default=_marker):
     # Return in ymd format, with zeros omitted
     ymd_values = map(str, ymd_values)
     ymd = filter(lambda it: int(it[0]), zip(ymd_values, "ymd"))
-    return " ".join(map("".join, ymd))
+    ymd = " ".join(map("".join, ymd))
+
+    # return a compliant ymd when no elapsed days
+    return ymd or "0d"
 
 
 def is_ymd(ymd):

--- a/src/senaite/patient/tests/doctests/API.rst
+++ b/src/senaite/patient/tests/doctests/API.rst
@@ -52,6 +52,11 @@ Returns a TypeError if the value is not of the expected type:
 
 Returns a ValueError if the value has the rihgt type, but format is wrong:
 
+    >>> api.to_ymd("")
+    Traceback (most recent call last):
+    [...]
+    ValueError: Not a valid ymd: ''
+
     >>> api.to_ymd("123")
     Traceback (most recent call last):
     [...]
@@ -102,6 +107,9 @@ Returns true for ymd-like strings:
     True
 
     >>> api.is_ymd("0y0m0d")
+    True
+
+    >>> api.is_ymd("0d")
     True
 
 But returns false if the format or type is not valid:

--- a/src/senaite/patient/tests/doctests/API.rst
+++ b/src/senaite/patient/tests/doctests/API.rst
@@ -33,10 +33,6 @@ We can convert a relativedelta to ymd format:
     >>> api.to_ymd(period)
     '6m 2d'
 
-    >>> period = relativedelta()
-    >>> api.to_ymd(period)
-    ''
-
 Or can transform an already existing ymd to its standard format:
 
     >>> api.to_ymd("1y2m3d")
@@ -65,6 +61,18 @@ Returns a ValueError if the value has the rihgt type, but format is wrong:
     Traceback (most recent call last):
     [...]
     ValueError: Not a valid ymd: 'y123d'
+
+And returns a ymd-compliant result when current date or no period is set:
+
+    >>> period = relativedelta()
+    >>> api.to_ymd(period)
+    '0d'
+
+    >>> api.to_ymd("0y")
+    '0d'
+
+    >>> api.to_ymd("0y0m0d")
+    '0d'
 
 Function is even aware of monthly and yearly shifts:
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the `api.to_ymd` function to return a compliant ymd when no elapsed days

## Current behavior before PR

When no days elapsed, `to_ymd` returns an empty string

## Desired behavior after PR is merged

When no days elapsed, `to_ymd` returns `0d`, that is ymd-compliant

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
