### PR TITLE
Fix traceback when creating partitions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #79 Fix traceback when creating partitions
 - #78 Make to_ymd return a compliant ymd when no elapsed days
 - #77 Use system's default timezone for TZ-naive birth dates
 - #76 Fix tracbeack on DateOfBirth update while validation fails for others

--- a/src/senaite/patient/browser/widgets/agedob.py
+++ b/src/senaite/patient/browser/widgets/agedob.py
@@ -41,7 +41,16 @@ class AgeDoBWidget(DateTimeWidget):
         # We always return a dict suitable for the field
         output = dict.fromkeys(["dob", "from_age", "estimated"], False)
 
-        if dtime.is_date(value):
+        if isinstance(value, (list, tuple)):
+            # assume (dob, from_age, estimated)
+            if not value:
+                return None, {}
+            output["dob"] = dtime.to_dt(value[0])
+            output["from_age"] = value[1]
+            output["estimated"] = value[2]
+            return output, {}
+
+        elif dtime.is_date(value):
             # handle date-like objects directly
             output["dob"] = dtime.to_dt(value)
             return output, {}

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -157,7 +157,10 @@ And that is not estimated:
     False
 
 Or we can simply set the Birth date with age in ymd format. In such case, the
-system recognizes the date of birth was set from age
+system recognizes the date of birth was set from age. Note that sample's
+`getAgeYmd` returns the age of the patient when the sample was collected.
+Therefore, we need to extract the age directly from the field to properly
+assign the age of the patient at present time:
 
     >>> ymd = sample.getField("DateOfBirth").get_age_ymd(sample)
     >>> sample.setDateOfBirth(ymd)

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -58,6 +58,7 @@ Variables:
     >>> setup = api.get_setup()
     >>> patients = portal.patients
     >>> birthdate = DateTime("1980-02-25")
+    >>> sampled = DateTime("2023-05-19")
 
 Test fixture:
 
@@ -82,7 +83,15 @@ Patient Sample Integration
 
 Create a new sample:
 
-    >>> sample = new_sample([MC, MS], client, contact, sampletype, MedicalRecordNumber="4711", PatientFullName="Clark Kent", Sex="m", Gender="d", DateOfBirth=birthdate)
+    >>> sample = new_sample(
+    ...     [MC, MS], client, contact, sampletype,
+    ...     date_sampled=sampled,
+    ...     MedicalRecordNumber="4711",
+    ...     PatientFullName="Clark Kent",
+    ...     Sex="m",
+    ...     Gender="d",
+    ...     DateOfBirth=birthdate
+    ... )
     >>> api.get_workflow_status_of(sample)
     'sample_due'
 
@@ -148,9 +157,9 @@ And that is not estimated:
     False
 
 Or we can simply set the Birth date with age in ymd format. In such case, the
-system recognizes the date of birth was set from age:
+system recognizes the date of birth was set from age
 
-    >>> ymd = sample.getAgeYmd()
+    >>> ymd = sample.getField("DateOfBirth").get_age_ymd(sample)
     >>> sample.setDateOfBirth(ymd)
     >>> dob = sample.getDateOfBirth()
     >>> dtime.to_ansi(dob[0], show_time=False)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that arises when creating partitions


## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.partition_magic, line 98, in __call__
  Module bika.lims.utils.analysisrequest, line 434, in create_partition
  Module bika.lims.utils.analysisrequest, line 92, in create_analysisrequest
  Module Products.Archetypes.BaseObject, line 676, in processForm
  Module Products.Archetypes.BaseObject, line 653, in _processForm
   - __traceback_info__: (<AnalysisRequest at /senaite/clients/client-1/62cdd3eba4c92cd8c485d1c6c6f7433d>, <Field PatientAddress(text:rw)>, <function mutator at 0x7f86c2db7f50>)
  Module senaite.patient.browser.widgets.agedob, line 55, in process_form
AttributeError: 'tuple' object has no attribute 'get'
```

## Desired behavior after PR is merged

No complains

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
