### PR TITLE
Display error when no value is entered for Medical Record Number

### DIFF
--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -200,7 +200,7 @@ class IPatientControlPanel(Interface):
         title=_(u"Require Medical Record Number (MRN)"),
         description=_(
             u"Make the MRN field mandatory in the sample registration form "
-            u"and when creating or modifiying patients."
+            u"and when creating or modifying patients."
         ),
         required=False,
         default=True,

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/temporaryidentifierwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/temporaryidentifierwidget.pt
@@ -27,7 +27,12 @@
       </tal:values>
     </metal:view_macro>
 
-    <metal:view_macro define-macro="edit">
+    <metal:edit_macro define-macro="edit">
+
+      <tal:values define="required field/required|nothing;
+                          required python: required and 'required' or None;
+                          error_id python: errors.get(fieldName);">
+
       <div class="form form-inline field ArchetypesTemporaryIdentifierWidget TemporaryIdentifier"
           tal:define="values python:field.getEditAccessor(here)() or {};
                       session_values python:here.session_restore_value(fieldName, values);
@@ -43,8 +48,6 @@
           tal:attributes="class css_class;
                           id string:archetypes-fieldname-${fieldName};
                           data-fieldname string:${fieldName}">
-
-        <div class="fieldErrorBox" tal:condition="required"></div>
 
         <!-- Input text field -->
         <div class="form-group mr-2">
@@ -80,7 +83,11 @@
                tal:attributes="value string:${auto_id_marker}"/>
       </div>
 
-    </metal:view_macro>
+      <div class="fieldErrorBox" tal:condition="required"></div>
+      <div class="fieldErrorBox" tal:content="error_id" i18n:translate=""></div>
+
+      </tal:values>
+    </metal:edit_macro>
 
     <metal:search_macro define-macro="search">
       <div metal:use-macro="context/widgets/string/macros/edit"></div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request displays a message in red when no Medical Record Number on sample submit and patient's setting "Require Medical Record Number (MRN)" is enabled:

![Captura de 2023-08-24 17-56-44](https://github.com/senaite/senaite.patient/assets/832627/b6e7601a-a9c5-4050-a9d1-f8b03e327d87)


## Current behavior before PR

No error message after submit

## Desired behavior after PR is merged

Error message after submit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
