### PR TITLE
Fix failing GitHub Action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,8 @@ env:
 jobs:
   build-and-test:
     runs-on: 'ubuntu-20.04'
+    container:
+      image: python:2.7.18-buster
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -23,6 +25,7 @@ jobs:
         run: |
           pip install virtualenv
           virtualenv -p `which python` .
+          bin/pip install --upgrade pip
           bin/pip install -r requirements.txt
           bin/buildout -N -t 3 annotate
           bin/buildout -N -t 3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,10 +11,6 @@ jobs:
       image: python:2.7.18-buster
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '2.7.18'
-          cache: 'pip'
       - name: cache eggs
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the failing GitHub action

## Current behavior before PR

Error occurs when running the GitHub action:
```
Error: The version '2.7.18' with architecture 'x64' was not found for Ubuntu 20.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

## Desired behavior after PR is merged

Action is running w/o errors

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
