### PR TITLE
Fix traceback when adding a patient

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #82 Fix traceback when adding a patient
 - #79 Fix traceback when creating partitions
 - #78 Make to_ymd return a compliant ymd when no elapsed days
 - #77 Use system's default timezone for TZ-naive birth dates

--- a/src/senaite/patient/browser/patient/views.py
+++ b/src/senaite/patient/browser/patient/views.py
@@ -2,8 +2,9 @@
 
 import copy
 
-from plone.dexterity.browser import add
 from plone.dexterity.browser import edit
+from senaite.core.browser.dexterity.add import DefaultAddForm
+from senaite.core.browser.dexterity.add import DefaultAddView
 from senaite.patient import messageFactory as _
 from senaite.patient.api import is_patient_required
 
@@ -25,7 +26,7 @@ def fiddle_schema_fields(fields):
         mrn.field = mrn_field
 
 
-class PatientAddForm(add.DefaultAddForm):
+class PatientAddForm(DefaultAddForm):
     """Patient edit view
     """
     portal_type = "Patient"
@@ -38,11 +39,8 @@ class PatientAddForm(add.DefaultAddForm):
         fiddle_schema_fields(self.fields)
 
 
-class PatientAddView(add.DefaultAddView):
+class PatientAddView(DefaultAddView):
     form = PatientAddForm
-
-    def __init__(self, context, request, ti=None):
-        super(PatientAddView, self).__init__(context, request, ti=ti)
 
 
 class PatientEditForm(edit.DefaultEditForm):

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -24,12 +24,12 @@ from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims.api.mail import is_valid_email_address
 from plone.autoform import directives
-from plone.dexterity.content import Container
 from plone.supermodel import model
 from plone.supermodel.directives import fieldset
 from Products.CMFCore import permissions
 from senaite.core.api import dtime
 from senaite.core.behaviors import IClientShareable
+from senaite.core.content.base import Container
 from senaite.core.schema import AddressField
 from senaite.core.schema import DatetimeField
 from senaite.core.schema import PhoneField
@@ -50,8 +50,8 @@ from senaite.patient.interfaces import IPatient
 from six import string_types
 from z3c.form.interfaces import NO_VALUE
 from zope import schema
-from zope.interface import Invalid
 from zope.interface import implementer
+from zope.interface import Invalid
 from zope.interface import invariant
 
 from .schema import IAdditionalEmailSchema

--- a/src/senaite/patient/content/patientfolder.py
+++ b/src/senaite/patient/content/patientfolder.py
@@ -18,8 +18,8 @@
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from plone.dexterity.content import Container
 from plone.supermodel import model
+from senaite.core.content.base import Container
 
 from senaite.core.interfaces import IHideActionsMenu
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses


> [!WARNING]  
> **Merge https://github.com/senaite/senaite.core/pull/2370 first**

This PR fixes a side-effect of the portal-catalog patch introduced in https://github.com/senaite/senaite.core/pull/2368

Linked issue: https://github.com/senaite/senaite.patient/issues/

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.add, line 138, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 145, in update
  Module plone.app.z3cform.csrf, line 22, in execute
  Module z3c.form.action, line 98, in execute
  Module z3c.form.button, line 315, in __call__
  Module z3c.form.button, line 170, in __call__
  Module plone.dexterity.browser.add, line 116, in handleAdd
  Module z3c.form.form, line 265, in createAndAdd
  Module plone.dexterity.browser.add, line 95, in add
AttributeError: 'NoneType' object has no attribute 'id'

```

## Desired behavior after PR is merged

No traceback, patient created correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
