### PR TITLE
Fix Patients are not created on Add Sample submit

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #83 Fix Patients are not created on Add sample form submit
 - #82 Fix traceback when adding a patient
 - #79 Fix traceback when creating partitions
 - #78 Make to_ymd return a compliant ymd when no elapsed days

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -19,20 +19,15 @@
 # Some rights reserved, see README and LICENSE.
 
 import re
-from bika.lims import deprecated
 from datetime import datetime
 
 from bika.lims import api
-from bika.lims.utils import tmpID
+from bika.lims import deprecated
 from dateutil.relativedelta import relativedelta
 from senaite.core.api import dtime
 from senaite.patient.config import PATIENT_CATALOG
 from senaite.patient.permissions import AddPatient
 from six import string_types
-from zope.component import getUtility
-from zope.component.interfaces import IFactory
-from zope.event import notify
-from zope.lifecycleevent import ObjectCreatedEvent
 
 CLIENT_TYPE = "Client"
 PATIENT_TYPE = "Patient"
@@ -146,35 +141,6 @@ def patient_search(query):
     """
     catalog = get_patient_catalog()
     return catalog(query)
-
-
-def create_temporary_patient():
-    """Create a new temporary patient object
-
-    :returns: temporary patient object
-    """
-    tid = tmpID()
-    portal_type = "Patient"
-    portal_types = api.get_tool("portal_types")
-    fti = portal_types.getTypeInfo(portal_type)
-    factory = getUtility(IFactory, fti.factory)
-    patient = factory(tid)
-    patient._setPortalTypeName(fti.getId())
-    return patient
-
-
-def store_temporary_patient(container, patient):
-    """Store temporary patient to the patients folder
-
-    :param container: The container where the patient should be stored
-    :param patient: A temporary patient object
-    """
-    # Notify `ObjectCreateEvent` to generate a UID first
-    notify(ObjectCreatedEvent(patient))
-    # set the patient in the container
-    container._setObject(patient.id, patient)
-    patient = container.get(patient.getId())
-    return patient
 
 
 def update_patient(patient, **values):

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -113,9 +113,8 @@ def update_patient(instance):
                     .format(api.get_path(container), mrn))
         values = get_patient_fields(instance)
         try:
-            patient = patient_api.create_temporary_patient()
+            patient = api.create(container, "Patient")
             patient_api.update_patient(patient, **values)
-            patient_api.store_temporary_patient(container, patient)
         except ValueError as exc:
             logger.error("%s" % exc)
             logger.error("Failed to create patient for values: %r" % values)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Patients are no longer created when submitted via Add Sample form

## Current behavior before PR

Patients are not created on Add sample form submit

## Desired behavior after PR is merged

Patients are created on Add sample form submit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
