### PR TITLE
Display "Not defined" in listing for patients without MRN set

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #84 Display "Not defined" in listing for patients without MRN se
 - #83 Fix Patients are not created on Add sample form submit
 - #82 Fix traceback when adding a patient
 - #79 Fix traceback when creating partitions

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -23,15 +23,15 @@ from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.interfaces import IClient
 from bika.lims.utils import get_email_link
+from bika.lims.utils import get_image
 from bika.lims.utils import get_link
-from plone.memoize import view
 from senaite.app.listing.view import ListingView
 from senaite.patient import messageFactory as _sp
 from senaite.patient.api import to_identifier_type_name
 from senaite.patient.api import tuplify_identifiers
 from senaite.patient.catalog import PATIENT_CATALOG
+from senaite.patient.i18n import translate as t
 from senaite.patient.permissions import AddPatient
-from zope.component import getMultiAdapter
 
 
 class PatientFolderView(ListingView):
@@ -117,15 +117,6 @@ class PatientFolderView(ListingView):
             },
         ]
 
-    @property
-    @view.memoize
-    def senaite_theme(self):
-        return getMultiAdapter((self.context, self.request),
-                               name="senaite_theme")
-
-    def icon_tag(self, name, **kwargs):
-        return self.senaite_theme.icon_tag(name, **kwargs)
-
     def update(self):
         """Update hook
         """
@@ -140,12 +131,6 @@ class PatientFolderView(ListingView):
         """Ensure UTF8 encoded string
         """
         return api.safe_unicode(s).encode("utf8")
-
-    def translate(self, message):
-        """Returns the translated message
-        """
-        ts = api.get_tool("translation_service")
-        return ts.translate(message)
 
     def get_identifier_tags(self, identifiers, klass="badge badge-light"):
         """Generate a list of identifier HTML tags
@@ -172,9 +157,8 @@ class PatientFolderView(ListingView):
         # MRN
         mrn = obj.getMRN()
         if not mrn:
-            item["before"]["mrn"] = self.icon_tag("info", width=16)
-            mrn = _("mrn_not_defined", default="Not defined")
-            mrn = self.translate(mrn)
+            item["before"]["mrn"] = get_image("info", width=16)
+            mrn = t(_sp("mrn_not_defined", default="Not defined"))
 
         item["mrn"] = self.to_utf8(mrn)
         item["replace"]["mrn"] = get_link(url, value=mrn)

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -19,18 +19,19 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
-
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.interfaces import IClient
 from bika.lims.utils import get_email_link
 from bika.lims.utils import get_link
+from plone.memoize import view
 from senaite.app.listing.view import ListingView
 from senaite.patient import messageFactory as _sp
 from senaite.patient.api import to_identifier_type_name
 from senaite.patient.api import tuplify_identifiers
 from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.permissions import AddPatient
+from zope.component import getMultiAdapter
 
 
 class PatientFolderView(ListingView):
@@ -116,6 +117,15 @@ class PatientFolderView(ListingView):
             },
         ]
 
+    @property
+    @view.memoize
+    def senaite_theme(self):
+        return getMultiAdapter((self.context, self.request),
+                               name="senaite_theme")
+
+    def icon_tag(self, name, **kwargs):
+        return self.senaite_theme.icon_tag(name, **kwargs)
+
     def update(self):
         """Update hook
         """
@@ -130,6 +140,12 @@ class PatientFolderView(ListingView):
         """Ensure UTF8 encoded string
         """
         return api.safe_unicode(s).encode("utf8")
+
+    def translate(self, message):
+        """Returns the translated message
+        """
+        ts = api.get_tool("translation_service")
+        return ts.translate(message)
 
     def get_identifier_tags(self, identifiers, klass="badge badge-light"):
         """Generate a list of identifier HTML tags
@@ -154,12 +170,14 @@ class PatientFolderView(ListingView):
         url = api.get_url(obj)
 
         # MRN
-        mrn = obj.getMRN() or obj.getId()
-        if mrn:
-            mrn = api.safe_unicode(mrn).encode("utf8")
-            item["mrn"] = mrn
-            item["replace"]["mrn"] = get_link(
-                url, value=mrn)
+        mrn = obj.getMRN()
+        if not mrn:
+            item["before"]["mrn"] = self.icon_tag("info", width=16)
+            mrn = _("mrn_not_defined", default="Not defined")
+            mrn = self.translate(mrn)
+
+        item["mrn"] = self.to_utf8(mrn)
+        item["replace"]["mrn"] = get_link(url, value=mrn)
 
         # Patient Identifiers
         identifiers = obj.getIdentifiers()
@@ -171,15 +189,13 @@ class PatientFolderView(ListingView):
         if fullname:
             fullname = api.safe_unicode(fullname).encode("utf8")
             item["fullname"] = fullname
-            item["replace"]["fullname"] = get_link(
-                url, value=fullname)
+            item["replace"]["fullname"] = get_link(url, value=fullname)
 
         # Email
         email = obj.getEmail()
         if email:
             item["email"] = email
-            item["replace"]["email"] = get_email_link(
-                email, value=email)
+            item["replace"]["email"] = get_email_link(email, value=email)
 
         # Email Report
         email_report = obj.getEmailReport()

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -318,6 +318,7 @@ class IPatientSchema(model.Schema):
             # MRN is not a required field
             return
 
+        import pdb;pdb.set_trace()
         if not data.mrn:
             raise Invalid(_("Patient Medical Record is missing or empty"))
 

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -318,7 +318,6 @@ class IPatientSchema(model.Schema):
             # MRN is not a required field
             return
 
-        import pdb;pdb.set_trace()
         if not data.mrn:
             raise Invalid(_("Patient Medical Record is missing or empty"))
 

--- a/src/senaite/patient/i18n.py
+++ b/src/senaite/patient/i18n.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.PATIENT.
+#
+# SENAITE.PATIENT is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020-2022 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+
+
+def translate(msgid, **kwargs):
+    """Translate any zope i18n msgid returned from MessageFactory
+    """
+    msgid = api.safe_unicode(msgid)
+
+    # XX: If the msgid is from type `Message`, Zope's i18n translate tool gives
+    #     priority `Message.domain` over the domain passed through kwargs
+    domain = kwargs.pop("domain", "senaite.patient")
+    params = {
+        "domain": getattr(msgid, "domain", domain),
+        "context": api.get_request(),
+    }
+    params.update(kwargs)
+
+    ts = api.get_tool("translation_service")
+    return ts.translate(msgid, **params)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When the configuration option "Require Medical Record Number (MRN)" is disabled, the "MRN" field in Patient add/edit view is not required and therefore, Patient objects with empty MRN can be created. In those cases, the internal ID of the patient is displayed in the patients listing.

This Pull Request displays "Not defined" instead of the object internal ID for patients with an empty MRN.

## Current behavior before PR

Patient internal id is displayed as MRN in listing for patients without MRN set.

## Desired behavior after PR is merged

"Not defined", along with an alert is displayed as MRN in listing for patients without MRN set

![Captura de 2023-09-20 11-27-01](https://github.com/senaite/senaite.patient/assets/832627/a134ede1-5467-467e-b13d-1b6a553d0086)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
