### PR TITLE
Remove display_template from sample mrn

### DIFF
--- a/src/senaite/patient/content/analysisrequest.py
+++ b/src/senaite/patient/content/analysisrequest.py
@@ -80,7 +80,6 @@ MedicalRecordNumberField = TemporaryIdentifierField(
         },
         search_index="patient_searchable_mrn",
         value_key="mrn",
-        display_template="${mrn}",
         search_wildcard=True,
         multi_valued=False,
         allow_user_value=True,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the `display_template` introduced in https://github.com/senaite/senaite.patient/pull/85 to render the plain value in the samples MRN field.
 
## Current behavior before PR

`${mrn}` is displayed for the sample MRN field

## Desired behavior after PR is merged

The selected MRN value is displayed for the sample MRN field

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
