### PR TITLE
Display all samples by default in Patient context

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #88 Display all samples by default in Patient context
 - #86 Fix non-unique MRNs are permitted when "Require MRN" setting is enabled
 - #84 Display "Not defined" in listing for patients without MRN set
 - #85 Display MRN instead of fullname in temporary identifier widget

--- a/src/senaite/patient/browser/patient/samples.py
+++ b/src/senaite/patient/browser/patient/samples.py
@@ -11,8 +11,15 @@ class SamplesView(BaseView):
     def __init__(self, context, request):
         super(SamplesView, self).__init__(context, request)
 
+        # display "All" samples by default
+        self.default_review_state = "all"
+
         fullname = self.context.getFullname()
-        self.title = _("Samples of {}").format(api.safe_unicode(fullname))
+        self.title = _(
+            "title_patient_samples_listing",
+            "Samples of ${patient_fullname}",
+            mapping={"patient_fullname": api.safe_unicode(fullname)}
+        )
 
         mrn = self.context.getMRN()
         if mrn:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!WARNING]  
> **Review and merge https://github.com/senaite/senaite.app.listing/pull/118 first**

This Pull Request ensures that by default, the filter "All" is selected in samples listing from inside Patient. Reason is that we don't expect hundreds of samples from a Patient, but a few. Also, the samples listing in that context is commonly used for listing samples regardless of their status within the laboratory analysis workflow.

## Current behavior before PR

By default, system displays samples in "Active" status in Patient context

## Desired behavior after PR is merged

By default, system displays samples in "All" status in Patient context

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
