### PR TITLE
Fix addition of snapshots in PatientFolder on Patient creation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #89 Fix addition of snapshots in PatientFolder on Patient creation
 - #88 Display all samples by default in Patient context
 - #86 Fix non-unique MRNs are permitted when "Require MRN" setting is enabled
 - #84 Display "Not defined" in listing for patients without MRN set

--- a/src/senaite/patient/content/patientfolder.py
+++ b/src/senaite/patient/content/patientfolder.py
@@ -18,11 +18,10 @@
 # Copyright 2020-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims.interfaces import IDoNotSupportSnapshots
 from plone.supermodel import model
 from senaite.core.content.base import Container
-
 from senaite.core.interfaces import IHideActionsMenu
-
 from zope.interface import implementer
 
 
@@ -32,7 +31,7 @@ class IPatientFolder(model.Schema):
     pass
 
 
-@implementer(IPatientFolder, IHideActionsMenu)
+@implementer(IPatientFolder, IDoNotSupportSnapshots, IHideActionsMenu)
 class PatientFolder(Container):
     """Patient Folder
     """

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1413</version>
+  <version>1414</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,7 +2,16 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
-  <!-- 1413: Dix duplicate MRNs -->
+  <!-- 1414: Fix Auditlog for Patient folder  -->
+  <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Remove snapshots from Patient folder"
+      description="Remove snapshots and auditlog from Patient folder"
+      source="1413"
+      destination="1414"
+      handler=".v01_04_000.remove_patientfolder_snapshots"
+      profile="senaite.patient:default"/>
+
+  <!-- 1413: Fix duplicate MRNs -->
   <genericsetup:upgradeStep
       title="SENAITE PATIENT 1.4.0: Fix MRN duplicates"
       description="Fix MRN duplicates"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the snapshots from `PatientFolder` and marks the object with `IDoNotSupportSnapshots` (and removes `IAuditable` marker as well).

## Current behavior before PR

System adds an snapshot for each modification of Patient folder, the addition of patients included

```
/home/senaite/buildout-cache/eggs/ZODB-5.8.0-py2.7.egg/ZODB/Connection.py:578: 
UserWarning: The <class 'persistent.list.PersistentList'> object
you're saving is large. (21919517 bytes.)

Perhaps you're storing media which should be stored in blobs.                                                                                               
Perhaps you're using a non-scalable data structure, such as a
PersistentMapping or PersistentList.

Perhaps you're storing data in objects that aren't persistent at
all. In cases like that, the data is stored in the record of the
containing persistent object.

In any case, storing records this big is probably a bad idea.
If you insist and want to get rid of this warning, use the
large_record_size option of the ZODB.DB constructor (or the
large-record-size option in a configuration file) to specify a larger size.                                                                                                                                                       
  warnings.warn(large_object_message % (obj.__class__, len(p)))
```

where the `PersistentList` object is the list of snapshosts, one per Patient added

## Desired behavior after PR is merged

System does not store snapshots for this folder

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
