### PR TITLE
Compatibility with core#2399

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #90 Compatibility with core#2399
 - #89 Fix addition of snapshots in PatientFolder on Patient creation
 - #88 Display all samples by default in Patient context
 - #86 Fix non-unique MRNs are permitted when "Require MRN" setting is enabled

--- a/src/senaite/patient/content/analysisrequest.py
+++ b/src/senaite/patient/content/analysisrequest.py
@@ -150,7 +150,7 @@ dob_field = AgeDateOfBirthField(
         render_own_label=True,
         default_age=True,
         show_time=False,
-        datepicker_nofuture=True,
+        max="current",
         visible={
             "add": "edit",
         }

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -295,7 +295,7 @@ class IPatientSchema(model.Schema):
 
     directives.widget("birthdate",
                       DatetimeWidget,
-                      datepicker_nofuture=True,
+                      max="current",
                       show_time=False)
     birthdate = DatetimeField(
         title=_(u"label_patient_birthdate", default=u"Birthdate"),

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -149,13 +149,15 @@
             <div class="input-group input-group-sm flex-nowrap d-inline-flex w-auto">
               <input type="date"
                      style="min-width:130px;max-width:130px"
-                     tal:define="invalid_class python: 'is-invalid' if dob_estimated else ''"
-                     tal:attributes="python:widget.attrs(here);
+                     tal:define="invalid_class python: 'is-invalid' if dob_estimated else '';
+                                 widget_attrs python: widget.attrs(here, field);"
+                     tal:attributes="
                          id string:${subfield_dob};
                          name string:${subfield_dob};
                          required python:required and 'required' or None;
                          value python: value;
-                         class python: 'form-control form-control-sm {}'.format(invalid_class);"/>
+                         class python: 'form-control form-control-sm {}'.format(invalid_class);
+                         python:widget_attrs"/>
 
               <div tal:condition="dob_estimated"
                    class="form-control form-control-sm text-danger border-danger">

--- a/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
+++ b/src/senaite/patient/skins/templates/senaite_patient_widgets/agedobwidget.pt
@@ -150,7 +150,7 @@
               <input type="date"
                      style="min-width:130px;max-width:130px"
                      tal:define="invalid_class python: 'is-invalid' if dob_estimated else ''"
-                     tal:attributes="python:widget.attrs();
+                     tal:attributes="python:widget.attrs(here);
                          id string:${subfield_dob};
                          name string:${subfield_dob};
                          required python:required and 'required' or None;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes `senaite.patient` compatible with https://github.com/senaite/senaite.core/pull/2399

## Current behavior before PR

`senaite.patient` is not compatible with latest datetimewidget changes

## Desired behavior after PR is merged

`senaite.patient` is compatible with latest datetimewidget changes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
