### PR TITLE
Allow only 1 Patient per Report

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #91 Allow only 1 Patient per Report
 - #90 Compatibility with core#2399
 - #89 Fix addition of snapshots in PatientFolder on Patient creation
 - #88 Display all samples by default in Patient context

--- a/src/senaite/patient/adapters/configure.zcml
+++ b/src/senaite/patient/adapters/configure.zcml
@@ -9,6 +9,10 @@
     factory=".guards.SampleGuardAdapter"
     name="senaite.patient.adapter.guard.sample" />
 
+  <!-- Group Key Provider to allow only 1 Patient per Report
+       https://github.com/senaite/senaite.impress/pull/145 -->
+  <adapter factory=".impress.GroupKeyProvider" />
+
   <!-- Visibility of Gender field -->
   <adapter
       factory=".widgetvisibility.GenderFieldVisibility"

--- a/src/senaite/patient/adapters/impress.py
+++ b/src/senaite/patient/adapters/impress.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims.interfaces import IAnalysisRequest
+from senaite.impress.interfaces import IGroupKeyProvider
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@implementer(IGroupKeyProvider)
+@adapter(IAnalysisRequest)
+class GroupKeyProvider(object):
+    """Provide a grouping key for PDF separation
+    """
+    def __init__(self, context):
+        self.context = context
+
+    def __call__(self):
+        client_uid = self.context.getClientUID()
+        mrn = self.context.getMedicalRecordNumberValue()
+        if mrn:
+            return "%s_%s" % (client_uid, mrn)
+        return client_uid


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a `senaite.impress` group key provider that mixes in the Patient MRN to split reports.

## Current behavior before PR

Multiple patients are allowed in one (multi-)report PDF

## Desired behavior after PR is merged

Only 1 patient is allowed in one (multi-)report PDF

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
