### PR TITLE
  Allow searches by patient in samples listing 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #92 Allow searches by patient in samples listing
 - #91 Allow only 1 Patient per Report
 - #90 Compatibility with core#2399
 - #89 Fix addition of snapshots in PatientFolder on Patient creation

--- a/src/senaite/patient/catalog/configure.zcml
+++ b/src/senaite/patient/catalog/configure.zcml
@@ -1,23 +1,7 @@
-<configure
-    xmlns="http://namespaces.zope.org/zope"
-    i18n_domain="senaite.patient">
+<configure xmlns="http://namespaces.zope.org/zope"
+           i18n_domain="senaite.patient">
 
-  <!-- Sample (aka AnalysisRequest) Index Adapters -->
-  <adapter name="is_temporary_mrn" factory=".indexers.is_temporary_mrn"/>
-  <adapter name="medical_record_number" factory=".indexers.medical_record_number"/>
-
-  <!-- Patient Indexes -->
-  <adapter name="patient_mrn" factory=".indexers.patient_mrn" />
-  <adapter name="patient_identifier_keys" factory=".indexers.patient_identifier_keys" />
-  <adapter name="patient_identifier_values" factory=".indexers.patient_identifier_values" />
-  <adapter name="patient_race_keys" factory=".indexers.patient_race_keys" />
-  <adapter name="patient_ethnicity_keys" factory=".indexers.patient_ethnicity_keys" />
-  <adapter name="patient_marital_status" factory=".indexers.patient_marital_status" />
-  <adapter name="patient_email" factory=".indexers.patient_email" />
-  <adapter name="patient_email_report" factory=".indexers.patient_email_report" />
-  <adapter name="patient_birthdate" factory=".indexers.patient_birthdate" />
-  <adapter name="patient_fullname" factory=".indexers.patient_fullname" />
-  <adapter name="patient_searchable_text" factory=".indexers.patient_searchable_text" />
-  <adapter name="patient_searchable_mrn" factory=".indexers.patient_searchable_mrn" />
+  <!-- Catalog indexes -->
+  <include package=".indexer" />
 
 </configure>

--- a/src/senaite/patient/catalog/indexer/__init__.py
+++ b/src/senaite/patient/catalog/indexer/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.PATIENT.
+#
+# SENAITE.PATIENT is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/patient/catalog/indexer/configure.zcml
+++ b/src/senaite/patient/catalog/indexer/configure.zcml
@@ -1,0 +1,23 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="senaite.patient">
+
+  <!-- Sample (aka AnalysisRequest) Index Adapters -->
+  <adapter name="is_temporary_mrn" factory=".sample.is_temporary_mrn"/>
+  <adapter name="medical_record_number" factory=".sample.medical_record_number"/>
+
+  <!-- Patient Indexes -->
+  <adapter name="patient_mrn" factory=".patient.patient_mrn" />
+  <adapter name="patient_identifier_keys" factory=".patient.patient_identifier_keys" />
+  <adapter name="patient_identifier_values" factory=".patient.patient_identifier_values" />
+  <adapter name="patient_race_keys" factory=".patient.patient_race_keys" />
+  <adapter name="patient_ethnicity_keys" factory=".patient.patient_ethnicity_keys" />
+  <adapter name="patient_marital_status" factory=".patient.patient_marital_status" />
+  <adapter name="patient_email" factory=".patient.patient_email" />
+  <adapter name="patient_email_report" factory=".patient.patient_email_report" />
+  <adapter name="patient_birthdate" factory=".patient.patient_birthdate" />
+  <adapter name="patient_fullname" factory=".patient.patient_fullname" />
+  <adapter name="patient_searchable_text" factory=".patient.patient_searchable_text" />
+  <adapter name="patient_searchable_mrn" factory=".patient.patient_searchable_mrn" />
+
+</configure>

--- a/src/senaite/patient/catalog/indexer/configure.zcml
+++ b/src/senaite/patient/catalog/indexer/configure.zcml
@@ -6,6 +6,13 @@
   <adapter name="is_temporary_mrn" factory=".sample.is_temporary_mrn"/>
   <adapter name="medical_record_number" factory=".sample.medical_record_number"/>
 
+  <!-- Additional tokens for listing_searchable_text -->
+  <adapter
+      for="bika.lims.interfaces.IAnalysisRequest
+           senaite.core.interfaces.ISampleCatalog"
+      provides="bika.lims.interfaces.IListingSearchableTextProvider"
+      factory=".sample.ListingSearchableTextProvider"/>
+
   <!-- Patient Indexes -->
   <adapter name="patient_mrn" factory=".patient.patient_mrn" />
   <adapter name="patient_identifier_keys" factory=".patient.patient_identifier_keys" />

--- a/src/senaite/patient/catalog/indexer/patient.py
+++ b/src/senaite/patient/catalog/indexer/patient.py
@@ -15,26 +15,11 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# Copyright 2020-2022 by it's authors.
+# Copyright 2020-2023 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims.interfaces import IAnalysisRequest
 from plone.indexer import indexer
 from senaite.patient.interfaces import IPatient
-
-
-@indexer(IAnalysisRequest)
-def is_temporary_mrn(instance):
-    """Returns whether the Medical Record Number is temporary
-    """
-    return instance.isMedicalRecordTemporary()
-
-
-@indexer(IAnalysisRequest)
-def medical_record_number(instance):
-    """Returns the Medical Record Number value assigned to the sample
-    """
-    return [instance.getMedicalRecordNumberValue() or None]
 
 
 @indexer(IPatient)

--- a/src/senaite/patient/catalog/indexer/sample.py
+++ b/src/senaite/patient/catalog/indexer/sample.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.PATIENT.
+#
+# SENAITE.PATIENT is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims.interfaces import IAnalysisRequest
+from plone.indexer import indexer
+
+
+@indexer(IAnalysisRequest)
+def is_temporary_mrn(instance):
+    """Returns whether the Medical Record Number is temporary
+    """
+    return instance.isMedicalRecordTemporary()
+
+
+@indexer(IAnalysisRequest)
+def medical_record_number(instance):
+    """Returns the Medical Record Number value assigned to the sample
+    """
+    return [instance.getMedicalRecordNumberValue() or None]

--- a/src/senaite/patient/catalog/indexer/sample.py
+++ b/src/senaite/patient/catalog/indexer/sample.py
@@ -19,7 +19,11 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims.interfaces import IAnalysisRequest
+from bika.lims.interfaces import IListingSearchableTextProvider
 from plone.indexer import indexer
+from senaite.core.interfaces import ISampleCatalog
+from zope.component import adapter
+from zope.interface import implementer
 
 
 @indexer(IAnalysisRequest)
@@ -34,3 +38,22 @@ def medical_record_number(instance):
     """Returns the Medical Record Number value assigned to the sample
     """
     return [instance.getMedicalRecordNumberValue() or None]
+
+
+@adapter(IAnalysisRequest, ISampleCatalog)
+@implementer(IListingSearchableTextProvider)
+class ListingSearchableTextProvider(object):
+    """Adapter that extends existing listing_searchable_text index with
+    additional tokens related with patient
+    """
+
+    def __init__(self, context, catalog):
+        self.context = context
+        self.catalog = catalog
+
+    def __call__(self):
+        tokens = [
+            self.context.getMedicalRecordNumberValue(),
+            self.context.getPatientFullName(),
+        ]
+        return filter(None, tokens)

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1414</version>
+  <version>1415</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/upgrade/v01_04_000.py
+++ b/src/senaite/patient/upgrade/v01_04_000.py
@@ -42,6 +42,7 @@ from senaite.patient.setuphandlers import setup_catalogs
 from zope.annotation.interfaces import IAnnotations
 from zope.interface import alsoProvides
 from zope.interface import noLongerProvides
+from Products.ZCatalog.ProgressHandler import ZLogHandler
 
 version = "1.4.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)
@@ -541,3 +542,13 @@ def remove_patientfolder_snapshots(tool):
         annotation[snapshot.SNAPSHOT_STORAGE] = PersistentList([storage[0]])
 
     logger.info("Removing snapshots from Patient Folder [DONE]")
+
+
+def allow_searches_by_patient_in_samples(tool):
+    """Reindex the `listing_searchable_text` index from AnalysisRequest type
+    so tokens with the patient name and mrn are added for searches
+    """
+    logger.info("Allowing searches by patient in samples ...")
+    cat = api.get_tool(SAMPLE_CATALOG)
+    cat.reindexIndex(["listing_searchable_text"], None, ZLogHandler())
+    logger.info("Allowing searches by patient in samples [DONE]")

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
-  <!-- 1414: Allow searches by patient in samples -->
+  <!-- 1415: Allow searches by patient in samples -->
   <genericsetup:upgradeStep
       title="SENAITE PATIENT 1.4.0: Allow patient searches in samples"
       description="

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,6 +2,18 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- 1414: Allow searches by patient in samples -->
+  <genericsetup:upgradeStep
+      title="SENAITE PATIENT 1.4.0: Allow patient searches in samples"
+      description="
+        This upgrade step adds the mrn and patient full name as tokens for the
+        existing `listing_searchable_text` index from samples catalog and does
+        the reindex of the index"
+      source="1414"
+      destination="1415"
+      handler=".v01_04_000.allow_searches_by_patient_in_samples"
+      profile="senaite.patient:default"/>
+
   <!-- 1414: Fix Auditlog for Patient folder  -->
   <genericsetup:upgradeStep
       title="SENAITE PATIENT 1.4.0: Remove snapshots from Patient folder"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the MRN and Patient fullname as tokens into the existing `listing_searchable_text` index from samples catalog. Therefore, searches by MRN and patient name are suppported.

## Current behavior before PR

Is not possible to search samples by patient name or MRN

## Desired behavior after PR is merged

Is possible to search samples by patient name or MRN

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
