### PR TITLE
Layered listing searchable text adapter

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #93 Layered listing searchable text adapter
 - #92 Allow searches by patient in samples listing
 - #91 Allow only 1 Patient per Report
 - #90 Compatibility with core#2399

--- a/src/senaite/patient/catalog/indexer/configure.zcml
+++ b/src/senaite/patient/catalog/indexer/configure.zcml
@@ -7,11 +7,7 @@
   <adapter name="medical_record_number" factory=".sample.medical_record_number"/>
 
   <!-- Additional tokens for listing_searchable_text -->
-  <adapter
-      for="bika.lims.interfaces.IAnalysisRequest
-           senaite.core.interfaces.ISampleCatalog"
-      provides="bika.lims.interfaces.IListingSearchableTextProvider"
-      factory=".sample.ListingSearchableTextProvider"/>
+  <adapter factory=".sample.ListingSearchableTextProvider"/>
 
   <!-- Patient Indexes -->
   <adapter name="patient_mrn" factory=".patient.patient_mrn" />

--- a/src/senaite/patient/catalog/indexer/sample.py
+++ b/src/senaite/patient/catalog/indexer/sample.py
@@ -22,6 +22,7 @@ from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IListingSearchableTextProvider
 from plone.indexer import indexer
 from senaite.core.interfaces import ISampleCatalog
+from senaite.patient.interfaces import ISenaitePatientLayer
 from zope.component import adapter
 from zope.interface import implementer
 
@@ -40,15 +41,15 @@ def medical_record_number(instance):
     return [instance.getMedicalRecordNumberValue() or None]
 
 
-@adapter(IAnalysisRequest, ISampleCatalog)
+@adapter(IAnalysisRequest, ISenaitePatientLayer, ISampleCatalog)
 @implementer(IListingSearchableTextProvider)
 class ListingSearchableTextProvider(object):
     """Adapter that extends existing listing_searchable_text index with
     additional tokens related with patient
     """
-
-    def __init__(self, context, catalog):
+    def __init__(self, context, request, catalog):
         self.context = context
+        self.request = request
         self.catalog = catalog
 
     def __call__(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**☝️ NOTE:** Please merge https://github.com/senaite/senaite.core/pull/2412 first!

This PR changes the listing searchable text adapter signature to include the request layer as well.

## Current behavior before PR

Listing searchable text adapter is *always* looked up, even if the add-on is not installed.

## Desired behavior after PR is merged

Listing searchable text adapter is *only* looked up, if the add-on is installed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
