### PR TITLE
Fix birth date is not displayed in patients listing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #97 Fix birth date is not displayed in patients listing
 - #93 Layered listing searchable text adapter
 - #92 Allow searches by patient in samples listing
 - #91 Allow only 1 Patient per Report

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -26,6 +26,7 @@ from bika.lims.utils import get_email_link
 from bika.lims.utils import get_image
 from bika.lims.utils import get_link
 from senaite.app.listing.view import ListingView
+from senaite.core.api import dtime
 from senaite.patient import messageFactory as _sp
 from senaite.patient.api import to_identifier_type_name
 from senaite.patient.api import tuplify_identifiers
@@ -193,8 +194,9 @@ class PatientFolderView(ListingView):
 
         # Birthdate
         birthdate = obj.getBirthdate()
-        if birthdate:
-            item["birthdate"] = self.ulocalized_time(birthdate, long_format=0)
+        # birthdate is a datetime.date object
+        birthdate = dtime.to_DT(birthdate)
+        item["birthdate"] = dtime.to_localized_time(birthdate)
 
         # Folder
         parent = api.get_parent(obj)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the birth date to be displayed in patients listing

## Current behavior before PR

The birth date is not displayed in patients listing

## Desired behavior after PR is merged

The birth date is displayed in patients listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
