### PR TITLE
Allow to flag patients as deceased

### DIFF
--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -111,6 +111,11 @@ class PatientFolderView(ListingView):
                 "contentFilter": {'is_active': False},
                 "columns": self.columns.keys(),
             }, {
+                "id": "deceased",
+                "title": _("Deceased"),
+                "contentFilter": {'patient_deceased': True},
+                "columns": self.columns.keys(),
+            }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
@@ -170,11 +175,16 @@ class PatientFolderView(ListingView):
             self.get_identifier_tags(identifiers))
 
         # Fullname
-        fullname = obj.getFullname()
-        if fullname:
-            fullname = api.safe_unicode(fullname).encode("utf8")
-            item["fullname"] = fullname
-            item["replace"]["fullname"] = get_link(url, value=fullname)
+        fullname_nd = t(_sp("fullname_not_defined", default="Not defined"))
+        fullname = obj.getFullname() or fullname_nd
+        fullname = api.safe_unicode(fullname).encode("utf8")
+
+        # Death dagger
+        if obj.getDeceased():
+            fullname = "{} <sup>&dagger;</sup>".format(fullname)
+
+        item["fullname"] = fullname
+        item["replace"]["fullname"] = get_link(url, value=fullname)
 
         # Email
         email = obj.getEmail()

--- a/src/senaite/patient/catalog/indexer/configure.zcml
+++ b/src/senaite/patient/catalog/indexer/configure.zcml
@@ -22,5 +22,6 @@
   <adapter name="patient_fullname" factory=".patient.patient_fullname" />
   <adapter name="patient_searchable_text" factory=".patient.patient_searchable_text" />
   <adapter name="patient_searchable_mrn" factory=".patient.patient_searchable_mrn" />
+  <adapter name="patient_deceased" factory=".patient.patient_deceased" />
 
 </configure>

--- a/src/senaite/patient/catalog/indexer/patient.py
+++ b/src/senaite/patient/catalog/indexer/patient.py
@@ -101,6 +101,13 @@ def patient_birthdate(instance):
 
 
 @indexer(IPatient)
+def patient_deceased(instance):
+    """Index deceased
+    """
+    return instance.getDeceased()
+
+
+@indexer(IPatient)
 def patient_searchable_text(instance):
     """Index for searchable text queries
     """

--- a/src/senaite/patient/catalog/patient_catalog.py
+++ b/src/senaite/patient/catalog/patient_catalog.py
@@ -42,6 +42,7 @@ INDEXES = BASE_INDEXES + [
     ("patient_birthdate", "", "DateIndex"),
     ("patient_searchable_text", "", "ZCTextIndex"),
     ("patient_searchable_mrn", "", "ZCTextIndex"),
+    ("patient_deceased", "", "BooleanIndex"),
 ]
 
 COLUMNS = BASE_COLUMNS + [

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -303,6 +303,17 @@ class IPatientSchema(model.Schema):
         required=False,
     )
 
+    deceased = schema.Bool(
+        title=_(
+            u"label_patient_deceased",
+            default=u"Deceased"),
+        description=_(
+            u"description_patient_deceased",
+            default=u"Select if the patient died"),
+        required=False,
+        default=False,
+    )
+
     @invariant
     def validate_mrn(data):
         """Checks if the patient MRN # is unique
@@ -731,3 +742,17 @@ class Patient(Container):
             output = Template(address_format).safe_substitute(record)
             output = filter(None, output.split(", "))
             return ", ".join(output)
+
+    @security.protected(permissions.View)
+    def getDeceased(self):
+        """Returns whether the patient is deceased
+        """
+        accessor = self.accessor("deceased")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setDeceased(self, value):
+        """Set if the patient deceased
+        """
+        mutator = self.mutator("deceased")
+        return mutator(self, value)

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1416</version>
+  <version>1417</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/upgrade/v01_04_000.zcml
+++ b/src/senaite/patient/upgrade/v01_04_000.zcml
@@ -2,6 +2,18 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- 1417: Allow to flag patients as deceased -->
+  <genericsetup:upgradeStep
+      title="Allow to flag patients as deceased"
+      description="
+        This upgrade step adds the field Deceased for patient content type, as
+        well as a new index 'patient_deceased' to allows to filter deceased
+        patients in patients listing."
+      source="1416"
+      destination="1417"
+      handler=".v01_04_000.upgrade_catalog_indexes"
+      profile="senaite.patient:default"/>
+
   <!-- 1416: Allow searches by patient in samples -->
   <genericsetup:upgradeStep
       title="Remove lead and trailing whitespaces from MRN"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows to flag patients as deceased. It also adds a filter button "Deceased" in patients listing, as well a dagger mark next to the fullname.

## Current behavior before PR

Is not possible to flag patients as deceased

## Desired behavior after PR is merged

Is possible to flag patients as deceased

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
