### PR TITLE
Fix AttributeError when DateOfBirth field is hidden in add sample

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- #100 Fix AttributeError when DateOfBirth field is hidden in add sample
 - #96 Use dtime.to_DT instead of api.to_date
 - #99 Do not include default races and ethnicities in locales
 - #97 Fix birth date is not displayed in patients listing

--- a/src/senaite/patient/browser/widgets/agedob.py
+++ b/src/senaite/patient/browser/widgets/agedob.py
@@ -61,6 +61,10 @@ class AgeDoBWidget(DateTimeWidget):
             output["from_age"] = True
             return output, {}
 
+        elif not isinstance(value, dict):
+            # value type is not supported
+            return None, {}
+
         if value.get("selector") == "age":
             # Age entered
             ymd = map(lambda p: value.get(p), ["years", "months", "days"])


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an error that arises on sample creation when the field `DateOfBirth` is disabled from the sample add form via "Manage Form Fields".

## Current behavior before PR

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module bika.lims.decorators, line 51, in decorator
  Module bika.lims.browser.analysisrequest.add2, line 708, in __call__
  Module bika.lims.browser.analysisrequest.add2, line 1745, in ajax_submit
  Module senaite.patient.browser.widgets.agedob, line 64, in process_form
AttributeError: 'str' object has no attribute 'get'
```

## Desired behavior after PR is merged

No traceback. The sample is created successfully

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
