### PR TITLE
Fix date of birth is not saved on submit (sample view)

### DIFF
--- a/src/senaite/patient/browser/widgets/agedob.py
+++ b/src/senaite/patient/browser/widgets/agedob.py
@@ -61,7 +61,10 @@ class AgeDoBWidget(DateTimeWidget):
             output["from_age"] = True
             return output, {}
 
-        elif not isinstance(value, dict):
+        try:
+            # We might get a ZPublisher.HTTPRequest.record
+            value = dict(value)
+        except ValueError:
             # value type is not supported
             return None, {}
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a bug introduced with #100 so the date of birth is no longer saved when edited in Sample edit view.

## Current behavior before PR

Date of birth is not saved on sample view form submit

## Desired behavior after PR is merged

Date of birth is saved on sample view form submit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
