### PR TITLE
Display birthdate in the pop-up for patient selection

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 1.4.0 (2023-01-10)
 ------------------
 
+- #104 Add method getBirthdateText for patient content
 - #101 Fix sex and gender are not translated properly in patients listing
 - #100 Fix AttributeError when DateOfBirth field is hidden in add sample
 - #96 Use dtime.to_DT instead of api.to_date

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ Changelog
 1.4.0 (2023-01-10)
 ------------------
 
-- #104 Add method getLocalizedBirthdate for patient content
+- #104 Display birthdate in the pop-up for patient selection
 - #101 Fix sex and gender are not translated properly in patients listing
 - #100 Fix AttributeError when DateOfBirth field is hidden in add sample
 - #96 Use dtime.to_DT instead of api.to_date

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ Changelog
 1.4.0 (2023-01-10)
 ------------------
 
-- #104 Add method getBirthdateText for patient content
+- #104 Add method getLocalizedBirthdate for patient content
 - #101 Fix sex and gender are not translated properly in patients listing
 - #100 Fix AttributeError when DateOfBirth field is hidden in add sample
 - #96 Use dtime.to_DT instead of api.to_date

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -204,7 +204,7 @@ class PatientFolderView(ListingView):
         item["gender"] = obj.getGenderText()
 
         # Birthdate
-        item["birthdate"] = obj.getBirthdateText()
+        item["birthdate"] = obj.getLocalizedBirthdate()
 
         # Folder
         parent = api.get_parent(obj)

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -25,7 +25,6 @@ from bika.lims.utils import get_email_link
 from bika.lims.utils import get_image
 from bika.lims.utils import get_link
 from senaite.app.listing.view import ListingView
-from senaite.core.api import dtime
 from senaite.patient import messageFactory as _
 from senaite.patient.api import to_identifier_type_name
 from senaite.patient.api import tuplify_identifiers
@@ -205,10 +204,7 @@ class PatientFolderView(ListingView):
         item["gender"] = obj.getGenderText()
 
         # Birthdate
-        birthdate = obj.getBirthdate()
-        # birthdate is a datetime.date object
-        birthdate = dtime.to_DT(birthdate)
-        item["birthdate"] = dtime.to_localized_time(birthdate)
+        item["birthdate"] = obj.getBirthdateText()
 
         # Folder
         parent = api.get_parent(obj)

--- a/src/senaite/patient/content/analysisrequest.py
+++ b/src/senaite/patient/content/analysisrequest.py
@@ -87,24 +87,29 @@ MedicalRecordNumberField = TemporaryIdentifierField(
         columns=[
             {
                 "name": "mrn",
-                "width": "25",
+                "width": "20",
                 "align": "left",
                 "label": _(u"MRN"),
             }, {
                 "name": "firstname",
-                "width": "25",
+                "width": "20",
                 "align": "left",
                 "label": _(u"Firstname"),
             }, {
                 "name": "middlename",
-                "width": "25",
+                "width": "20",
                 "align": "left",
                 "label": _(u"Middlename"),
             }, {
                 "name": "lastname",
-                "width": "25",
+                "width": "20",
                 "align": "left",
                 "label": _(u"Lastname"),
+            }, {
+                "name": "getLocalizedBirthdate",
+                "width": "20",
+                "align": "left",
+                "label": _(u"Birthdate"),
             },
         ],
         limit=3,

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -711,7 +711,8 @@ class Patient(Container):
     def getLocalizedBirthdate(self):
         """Returns the birthday with the field accessor
         """
-        return dtime.to_localized_time(self.getBirthdate())
+        birthdate = dtime.to_DT(self.getBirthdate())
+        return dtime.to_localized_time(birthdate)
 
     @security.protected(permissions.ModifyPortalContent)
     def setBirthdate(self, value):

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -707,6 +707,12 @@ class Patient(Container):
             value = value.date()
         return value
 
+    @security.protected(permissions.View)
+    def getBirthdateText(self):
+        """Returns the birthday with the field accessor
+        """
+        return dtime.to_localized_time(self.getBirthdate())
+
     @security.protected(permissions.ModifyPortalContent)
     def setBirthdate(self, value):
         """Set birthdate by the field accessor

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -708,7 +708,7 @@ class Patient(Container):
         return value
 
     @security.protected(permissions.View)
-    def getBirthdateText(self):
+    def getLocalizedBirthdate(self):
         """Returns the birthday with the field accessor
         """
         return dtime.to_localized_time(self.getBirthdate())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

No linked issue

## Current behavior before PR
Patient content type does not have a method collecting the birthdate of a patient as a string.  
Neither has Medical Record # field in Analysis Request form, a column with the birthdate,


## Desired behavior after PR is merged
Patient content type does have a method which collects the birthdate of a patient as a string and it applied where needed.
Add in Medical Record # field in Analysis Request form, a column with the birthdate,

![imatge](https://github.com/senaite/senaite.patient/assets/61150318/ea427d27-75ef-4f28-b29c-a875d246f004)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
