### PR TITLE
Skip patient creation if the user has no permissions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,9 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
-- #95 Support for dynamic analysis specs with MinAge, MaxAge and Sex columns
-- #98 Allow to flag patients as deceased
+- #106 Skip patient creation if the user has no permissions
+- #95  Support for dynamic analysis specs with MinAge, MaxAge and Sex columns
+- #98  Allow to flag patients as deceased
 
 
 1.4.0 (2023-01-10)

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -94,21 +94,9 @@ def update_patient(instance):
         else:
             # create the patient in the global patients folder
             container = patient_api.get_patient_folder()
+
         # check if the user is allowed to add a new patient
         if not patient_api.is_patient_creation_allowed(container):
-            logger.warn("User '{}' is not allowed to create patients in '{}'"
-                        " -> setting MRN to temporary".format(
-                            api.user.get_user_id(), api.get_path(container)))
-            # make the MRN temporary
-            # XXX: Refactor logic from Widget -> Field/DataManager
-            mrn_field = instance.getField("MedicalRecordNumber")
-            mrn = dict(mrn_field.get(instance))
-            mrn["temporary"] = True
-            mrn_field.set(instance, mrn)
-            message = _("You are not allowed to add a patient in {} folder. "
-                        "Medical Record Number set to Temporary."
-                        .format(api.get_title(container)))
-            instance.plone_utils.addPortalMessage(message, "error")
             return None
 
         logger.info("Creating new Patient in '{}' with MRN: '{}'"

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -23,7 +23,6 @@ from senaite.core.behaviors import IClientShareableBehavior
 from senaite.patient import api as patient_api
 from senaite.patient import check_installed
 from senaite.patient import logger
-from senaite.patient import messageFactory as _
 
 
 @check_installed(None)

--- a/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
+++ b/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
@@ -49,7 +49,7 @@ We need to create some basic objects for the test:
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
     >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
     >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
-    >>> department = api.create(setup.bika_departments, "Department", title="Clinical Lab", Manager=labcontact)
+    >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
     >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)
     >>> malaria = api.create(setup.bika_analysisservices, "AnalysisService", title="Malaria Count", Keyword="MC", Price="10", Category=category.UID(), Accredited=True)
     >>> sample = new_sample([malaria], client, contact, sampletype, sampled, DateOfBirth=birth_date)

--- a/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
+++ b/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
@@ -34,8 +34,8 @@ Variables:
 
     >>> portal = self.portal
     >>> request = self.request
-    >>> setup = api.get_bika_setup()
-    >>> bika_setup = api.get_senaite_setup()
+    >>> setup = api.get_senaite_setup()
+    >>> bika_setup = api.get_bika_setup()
     >>> sampled = DateTime("2020-12-01")
     >>> birth_date = DateTime("1979-12-07")
 

--- a/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
+++ b/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
@@ -48,7 +48,7 @@ We need to create some basic objects for the test:
 
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Blood", Prefix="B")
     >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
     >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)

--- a/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
+++ b/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
@@ -48,7 +48,7 @@ We need to create some basic objects for the test:
 
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
     >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
     >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)

--- a/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
+++ b/src/senaite/patient/tests/doctests/AgeDateOfBirthField.rst
@@ -34,7 +34,8 @@ Variables:
 
     >>> portal = self.portal
     >>> request = self.request
-    >>> setup = api.get_setup()
+    >>> setup = api.get_bika_setup()
+    >>> bika_setup = api.get_senaite_setup()
     >>> sampled = DateTime("2020-12-01")
     >>> birth_date = DateTime("1979-12-07")
 
@@ -47,11 +48,11 @@ We need to create some basic objects for the test:
 
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
-    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
-    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)
-    >>> malaria = api.create(setup.bika_analysisservices, "AnalysisService", title="Malaria Count", Keyword="MC", Price="10", Category=category.UID(), Accredited=True)
+    >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)
+    >>> malaria = api.create(bika_setup.bika_analysisservices, "AnalysisService", title="Malaria Count", Keyword="MC", Price="10", Category=category.UID(), Accredited=True)
     >>> sample = new_sample([malaria], client, contact, sampletype, sampled, DateOfBirth=birth_date)
 
 Get the field:

--- a/src/senaite/patient/tests/doctests/DynamicResultRanges.rst
+++ b/src/senaite/patient/tests/doctests/DynamicResultRanges.rst
@@ -134,7 +134,7 @@ Create some baseline objects for the test:
 
     >>> client = api.create(portal.clients, "Client", Name="Happy Pills", ClientID="HP")
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="EDTA", Prefix="EDTA")
+    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="EDTA", Prefix="EDTA")
     >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(setup.departments, "Department", title="Biochemistry", Manager=labcontact)
     >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Biochemistry", Department=department)

--- a/src/senaite/patient/tests/doctests/DynamicResultRanges.rst
+++ b/src/senaite/patient/tests/doctests/DynamicResultRanges.rst
@@ -123,7 +123,8 @@ Variables:
 
     >>> portal = self.portal
     >>> request = self.request
-    >>> setup = api.get_setup()
+    >>> setup = api.get_senaite_setup()
+    >>> bika_setup = api.get_bika_setup()
 
 Assign default roles for the user to test with:
 
@@ -133,16 +134,16 @@ Create some baseline objects for the test:
 
     >>> client = api.create(portal.clients, "Client", Name="Happy Pills", ClientID="HP")
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="EDTA", Prefix="EDTA")
-    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
-    >>> department = api.create(setup.bika_departments, "Department", title="Biochemistry", Manager=labcontact)
-    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Biochemistry", Department=department)
-    >>> Ht = api.create(setup.bika_analysisservices, "AnalysisService", title="Hematocrit", Keyword="Ht", Category=category)
+    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="EDTA", Prefix="EDTA")
+    >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Biochemistry", Manager=labcontact)
+    >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Biochemistry", Department=department)
+    >>> Ht = api.create(bika_setup.bika_analysisservices, "AnalysisService", title="Hematocrit", Keyword="Ht", Category=category)
 
 Create a default specification for the Sample type `EDTA`:
 
     >>> default_range = {"keyword": "Ht", "min": "35", "max": "60", "warn_min": "34", "warn_max": "61"}
-    >>> specification = api.create(setup.bika_analysisspecs, "AnalysisSpec", title="Blood ranges", SampleType=sampletype, ResultsRange=[default_range,])
+    >>> specification = api.create(bika_setup.bika_analysisspecs, "AnalysisSpec", title="Blood ranges", SampleType=sampletype, ResultsRange=[default_range,])
 
 Assign a DynamicAnalysisSpec with same data as the example given above:
 
@@ -160,7 +161,7 @@ Assign a DynamicAnalysisSpec with same data as the example given above:
     ... Ht,f,12y,18y,33,51
     ... Ht,m,18y,,39,54
     ... Ht,f,18y,,36,48"""
-    >>> ds = api.create(setup.dynamic_analysisspecs, "DynamicAnalysisSpec")
+    >>> ds = api.create(bika_setup.dynamic_analysisspecs, "DynamicAnalysisSpec")
     >>> ds.specs_file = to_excel(data)
     >>> specification.setDynamicAnalysisSpec(ds)
 

--- a/src/senaite/patient/tests/doctests/DynamicResultRanges.rst
+++ b/src/senaite/patient/tests/doctests/DynamicResultRanges.rst
@@ -134,7 +134,7 @@ Create some baseline objects for the test:
 
     >>> client = api.create(portal.clients, "Client", Name="Happy Pills", ClientID="HP")
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="EDTA", Prefix="EDTA")
+    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="EDTA", Prefix="EDTA")
     >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(setup.departments, "Department", title="Biochemistry", Manager=labcontact)
     >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Biochemistry", Department=department)

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -71,7 +71,7 @@ We need to create some basic objects for the test:
     >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
     >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
     >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -71,7 +71,7 @@ We need to create some basic objects for the test:
     >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Blood", Prefix="B")
     >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
     >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)

--- a/src/senaite/patient/tests/doctests/PatientSample.rst
+++ b/src/senaite/patient/tests/doctests/PatientSample.rst
@@ -55,7 +55,8 @@ Variables:
 
     >>> portal = self.portal
     >>> request = self.request
-    >>> setup = api.get_setup()
+    >>> setup = api.get_senaite_setup()
+    >>> bika_setup = api.get_bika_setup()
     >>> patients = portal.patients
     >>> birthdate = DateTime("1980-02-25")
     >>> sampled = DateTime("2023-05-19")
@@ -70,12 +71,12 @@ We need to create some basic objects for the test:
     >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
-    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
-    >>> department = api.create(setup.bika_departments, "Department", title="Clinical Lab", Manager=labcontact)
-    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)
-    >>> MC = api.create(setup.bika_analysisservices, "AnalysisService", title="Malaria Count", Keyword="MC", Price="10", Category=category.UID(), Accredited=True)
-    >>> MS = api.create(setup.bika_analysisservices, "AnalysisService", title="Malaria Species", Keyword="MS", Price="10", Category=category.UID(), Accredited=True)
+    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
+    >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)
+    >>> MC = api.create(bika_setup.bika_analysisservices, "AnalysisService", title="Malaria Count", Keyword="MC", Price="10", Category=category.UID(), Accredited=True)
+    >>> MS = api.create(bika_setup.bika_analysisservices, "AnalysisService", title="Malaria Species", Keyword="MS", Price="10", Category=category.UID(), Accredited=True)
 
 
 Patient Sample Integration

--- a/src/senaite/patient/tests/doctests/PatientWorkflow.rst
+++ b/src/senaite/patient/tests/doctests/PatientWorkflow.rst
@@ -66,7 +66,7 @@ We need to create some basic objects for the test:
     >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
     >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
     >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)

--- a/src/senaite/patient/tests/doctests/PatientWorkflow.rst
+++ b/src/senaite/patient/tests/doctests/PatientWorkflow.rst
@@ -57,7 +57,8 @@ Variables:
 
     >>> portal = self.portal
     >>> request = self.request
-    >>> setup = api.get_setup()
+    >>> setup = api.get_senaite_setup()
+    >>> bika_setup = api.get_bika_setup()
     >>> patients = portal.patients
 
 We need to create some basic objects for the test:
@@ -65,12 +66,12 @@ We need to create some basic objects for the test:
     >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
-    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
-    >>> department = api.create(setup.bika_departments, "Department", title="Clinical Lab", Manager=labcontact)
-    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)
-    >>> MC = api.create(setup.bika_analysisservices, "AnalysisService", title="Malaria Count", Keyword="MC", Price="10", Category=category.UID(), Accredited=True)
-    >>> MS = api.create(setup.bika_analysisservices, "AnalysisService", title="Malaria Species", Keyword="MS", Price="10", Category=category.UID(), Accredited=True)
+    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
+    >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)
+    >>> MC = api.create(bika_setup.bika_analysisservices, "AnalysisService", title="Malaria Count", Keyword="MC", Price="10", Category=category.UID(), Accredited=True)
+    >>> MS = api.create(bika_setup.bika_analysisservices, "AnalysisService", title="Malaria Species", Keyword="MS", Price="10", Category=category.UID(), Accredited=True)
 
 
 Patient Folder Workflow
@@ -410,7 +411,7 @@ All patient fields are editable in `to_be_verified`:
 
 Verify the results:
 
-    >>> setup.setSelfVerificationEnabled(True)
+    >>> bika_setup.setSelfVerificationEnabled(True)
 
     >>> transitioned = do_action_for(ms, "verify")
     >>> transitioned = do_action_for(mc, "verify")

--- a/src/senaite/patient/tests/doctests/PatientWorkflow.rst
+++ b/src/senaite/patient/tests/doctests/PatientWorkflow.rst
@@ -66,7 +66,7 @@ We need to create some basic objects for the test:
     >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
     >>> client = api.create(portal.clients, "Client", Name="General Hospital", ClientID="GH", MemberDiscountApplies=False)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
-    >>> sampletype = api.create(bika_setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Blood", Prefix="B")
     >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(setup.departments, "Department", title="Clinical Lab", Manager=labcontact)
     >>> category = api.create(bika_setup.bika_analysiscategories, "AnalysisCategory", title="Blood", Department=department)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side-effect that the patient MRN is set to temporary when an Analyst enters results for sample analyses

## Current behavior before PR

Patient MRN is set to temporary

## Desired behavior after PR is merged

If the current user has no permission to create a patient, simply skip it.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
