### PR TITLE
Compatibility with core#2563 (Move Dynamic Analysis Specs to Setup folder)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- #109 Compatibility with core#2563 (Move DynamicAnalysisSpecs to Setup folder)
 - #107 Compatibility with core#2567 (AnalysisCategory to DX)
 - #106 Skip patient creation if the user has no permissions
 - #95  Support for dynamic analysis specs with MinAge, MaxAge and Sex columns

--- a/src/senaite/patient/tests/doctests/DynamicResultRanges.rst
+++ b/src/senaite/patient/tests/doctests/DynamicResultRanges.rst
@@ -161,7 +161,7 @@ Assign a DynamicAnalysisSpec with same data as the example given above:
     ... Ht,f,12y,18y,33,51
     ... Ht,m,18y,,39,54
     ... Ht,f,18y,,36,48"""
-    >>> ds = api.create(bika_setup.dynamic_analysisspecs, "DynamicAnalysisSpec")
+    >>> ds = api.create(setup.dynamicanalysisspecs, "DynamicAnalysisSpec")
     >>> ds.specs_file = to_excel(data)
     >>> specification.setDynamicAnalysisSpec(ds)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes this product compatible with https://github.com/senaite/senaite.core/pull/2563

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
