### PR TITLE
Allow/Disallow the introduction of future dates of birth

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- #111 Allow/Disallow the introduction of future dates of birth
 - #110 Compatibility with core#2584 (SampleType to DX)
 - #108 Fix Traceback when creating partitions when no patient assigned
 - #109 Compatibility with core#2563 (Move DynamicAnalysisSpecs to Setup folder)

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -87,6 +87,13 @@ def is_gender_visible():
     return api.get_registry_record(key, default=True)
 
 
+def is_future_birthdate_allowed():
+    """Returns whether the introduction of a birth date in future is allowed
+    """
+    key = "senaite.patient.future_birthdate"
+    return api.get_registry_record(key, default=False)
+
+
 def is_age_supported():
     """Returns whether the introduction of age is supported
     """

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -260,7 +260,7 @@ class IPatientControlPanel(Interface):
         title=_(u"Future dates of birth"),
         description=_(
             u"If selected, the system will allow the introduction of future "
-            u"dates for birth."
+            u"dates of birth."
         ),
         required=False,
         default=False,

--- a/src/senaite/patient/browser/controlpanel.py
+++ b/src/senaite/patient/browser/controlpanel.py
@@ -148,6 +148,7 @@ class IPatientControlPanel(Interface):
         description=_(""),
         fields=[
             "patient_entry_mode",
+            "future_birthdate",
             "age_supported",
             "age_years",
             "gender_visible",
@@ -253,6 +254,16 @@ class IPatientControlPanel(Interface):
         ),
         required=False,
         default=True,
+    )
+
+    future_birthdate = schema.Bool(
+        title=_(u"Future dates of birth"),
+        description=_(
+            u"If selected, the system will allow the introduction of future "
+            u"dates for birth."
+        ),
+        required=False,
+        default=False,
     )
 
     age_supported = schema.Bool(

--- a/src/senaite/patient/content/analysisrequest.py
+++ b/src/senaite/patient/content/analysisrequest.py
@@ -155,7 +155,6 @@ dob_field = AgeDateOfBirthField(
         render_own_label=True,
         default_age=True,
         show_time=False,
-        max="current",
         visible={
             "add": "edit",
         }

--- a/src/senaite/patient/content/fields.py
+++ b/src/senaite/patient/content/fields.py
@@ -211,3 +211,10 @@ class AgeDateOfBirthField(ExtensionField, ObjectField):
         """Returns whether the date is estimated
         """
         return self.get(instance)[:][2]
+
+    def get_max(self, instance):
+        """Returns the max date allowed for date of birth
+        """
+        if patient_api.is_future_birthdate_allowed():
+            return dtime.datetime.max
+        return dtime.datetime.now()

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -65,7 +65,7 @@ from .schema import IRaceSchema
 POSSIBLE_ADDRESSES = [OTHER_ADDRESS, PHYSICAL_ADDRESS, POSTAL_ADDRESS]
 
 
-def get_max_dob(context=None):
+def get_max_birthdate(context=None):
     """Returns the max date for date of birth
     """
     if patient_api.is_future_birthdate_allowed():
@@ -313,7 +313,7 @@ class IPatientSchema(model.Schema):
     )
     # XXX core's DateTimeWidget relies on field's get_max function if not 'max'
     #     property is explicitly set to the widget
-    birthdate.get_max = get_max_dob
+    birthdate.get_max = get_max_birthdate
 
     deceased = schema.Bool(
         title=_(

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1501</version>
+  <version>1502</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/upgrade/v01_05_000.py
+++ b/src/senaite/patient/upgrade/v01_05_000.py
@@ -59,3 +59,13 @@ def upgrade_catalog_indexes(tool):
     # setup patient catalog to add new indexes
     setup_catalogs(portal)
     logger.info("Upgrade catalog indexes [DONE]")
+
+
+def import_registry(tool):
+    """Imports the registry tool
+    """
+    logger.info("Reimport registry tool ...")
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
+    logger.info("Reimport registry tool [DONE]")

--- a/src/senaite/patient/upgrade/v01_05_000.zcml
+++ b/src/senaite/patient/upgrade/v01_05_000.zcml
@@ -2,6 +2,17 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- 1502: Allow/Disallow future dates of birth -->
+  <genericsetup:upgradeStep
+      title="Add setting to allow/disallow future dates of birth"
+      description="
+        This upgrade step adds a configuration setting to allow or disallow
+        the introduction of future dates of birth. Non-allowed by default."
+      source="1501"
+      destination="1502"
+      handler=".v01_05_000.import_registry"
+      profile="senaite.patient:default"/>
+
   <!-- 1501: Allow to flag patients as deceased -->
   <genericsetup:upgradeStep
       title="Allow to flag patients as deceased"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds an additional setting in Patient's control panel that allows the user to enable or disable the introduction of future dates of birth on sample creation and patient creation/edition forms.

![Captura de 2024-08-16 10-54-03](https://github.com/user-attachments/assets/12123ffb-48dc-41a1-995b-9a3008764744)

## Current behavior before PR

User can enter future dates in patient creation/edition forms, but cannot in sample creation form

## Desired behavior after PR is merged

Entry of future dates of birth on both sample and patient forms depends on a setting

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
