### PR TITLE
Use default TZ when calculating birthdate if `on_date` param is not set

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- #112 Use default TZ when calculating birthdate if `on_date` param is not set
 - #111 Allow/Disallow the introduction of future dates of birth
 - #110 Compatibility with core#2584 (SampleType to DX)
 - #108 Fix Traceback when creating partitions when no patient assigned

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -300,6 +300,9 @@ def get_birth_date(period, on_date=None, default=_marker):
     on_date = dtime.to_dt(on_date)
     if not on_date:
         on_date = datetime.now()
+        # apply system's current time zone
+        tz = dtime.get_os_timezone()
+        on_date = dtime.to_zone(on_date, tz)
 
     # calculate the date when everything started
     delta = relativedelta(years=years, months=months, days=days)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to use system's default Timezone when calculating the date of birth via `api.get_birth_date` if no value for parameter `on_date` is explicitly set.

As a result, this fixes the following test:
https://github.com/senaite/senaite.patient/actions/runs/10426342600/job/28879098625#step:7:226

## Current behavior before PR

System does not take system's default TZ when calculating birthdate if `on_date` is not set

## Desired behavior after PR is merged

System does take system's default TZ when calculating birthdate if `on_date` is not set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
