### PR TITLE
Added estimated birthdate field to Patient content type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- #113 Added estimated birthdate field to Patient content type
 - #112 Use default TZ when calculating birthdate if `on_date` param is not set
 - #111 Allow/Disallow the introduction of future dates of birth
 - #110 Compatibility with core#2584 (SampleType to DX)

--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -161,6 +161,7 @@ def update_patient(patient, **values):
     patient.setSex(values.get("sex", ""))
     patient.setGender(values.get("gender", ""))
     patient.setBirthdate(values.get("birthdate"))
+    patient.setEstimatedBirthdate(values.get("estimated_birthdate", False))
     patient.setAddress(values.get("address"))
     # reindex the new values
     patient.reindexObject()

--- a/src/senaite/patient/browser/patient/add2.py
+++ b/src/senaite/patient/browser/patient/add2.py
@@ -60,9 +60,10 @@ class PatientSampleAddView(BaseView):
             address = self.context.getFormattedAddress()
             return api.to_utf8(address)
         elif name == "DateOfBirth":
-            birthdate = self.context.getBirthdate()
-            if birthdate:
-                return birthdate.strftime("%Y-%m-%d")
+            from_age = False
+            birthdate = self.context.getBirthdate(as_date=False)
+            estimated = self.context.getEstimatedBirthdate()
+            return [birthdate, from_age, estimated]
         elif name == "Sex":
             return self.context.getSex()
         elif name == "Gender":

--- a/src/senaite/patient/browser/patientfolder.py
+++ b/src/senaite/patient/browser/patientfolder.py
@@ -205,6 +205,9 @@ class PatientFolderView(ListingView):
 
         # Birthdate
         item["birthdate"] = obj.getLocalizedBirthdate()
+        if obj.getEstimatedBirthdate():
+            item["after"]["birthdate"] = get_image(
+                "warning.png", title=t(_("The birthdate is estimated")))
 
         # Folder
         parent = api.get_parent(obj)

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -315,6 +315,20 @@ class IPatientSchema(model.Schema):
     #     property is explicitly set to the widget
     birthdate.get_max = get_max_birthdate
 
+    estimated_birthdate = schema.Bool(
+        title=_(
+            u"label_patient_estimated_birthdate",
+            default=u"Birthdate is estimated"
+        ),
+        description=_(
+            u"description_patient_estimated_birthdate",
+            default=u"Select this option if the patient's date of birth is "
+                    u"estimated"
+        ),
+        default=False,
+        required=False,
+    )
+
     deceased = schema.Bool(
         title=_(
             u"label_patient_deceased",
@@ -795,4 +809,18 @@ class Patient(Container):
         """Set if the patient deceased
         """
         mutator = self.mutator("deceased")
+        return mutator(self, value)
+
+    @security.protected(permissions.View)
+    def getEstimatedBirthdate(self):
+        """Returns whether the patient's date of birth is estimated
+        """
+        accessor = self.accessor("estimated_birthdate")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setEstimatedBirthdate(self, value):
+        """Set if the patient's date of birth is estimated
+        """
+        mutator = self.mutator("estimated_birthdate")
         return mutator(self, value)

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -749,6 +749,7 @@ class Patient(Container):
         accessor = self.accessor("birthdate")
         value = accessor(self)
         # Return a plain date object to avoid timezone issues
+        # TODO Convert to current timezone and keep it as datetime instead!
         if dtime.is_dt(value) and as_date:
             value = value.date()
         return value

--- a/src/senaite/patient/subscribers/analysisrequest.py
+++ b/src/senaite/patient/subscribers/analysisrequest.py
@@ -117,7 +117,9 @@ def get_patient_fields(instance):
     mrn = instance.getMedicalRecordNumberValue()
     sex = instance.getField("Sex").get(instance)
     gender = instance.getField("Gender").get(instance)
-    birthdate = instance.getField("DateOfBirth").get(instance)
+    dob_field = instance.getField("DateOfBirth")
+    birthdate = dob_field.get_date_of_birth(instance)
+    estimated = dob_field.get_estimated(instance)
     address = instance.getField("PatientAddress").get(instance)
     field = instance.getField("PatientFullName")
     firstname = field.get_firstname(instance)
@@ -134,7 +136,8 @@ def get_patient_fields(instance):
         "mrn": mrn,
         "sex": sex,
         "gender": gender,
-        "birthdate": birthdate[0],
+        "birthdate": birthdate,
+        "estimated_birthdate": estimated,
         "address": address,
         "firstname": api.safe_unicode(firstname),
         "middlename": api.safe_unicode(middlename),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the field `estimated_birthdate` to `Patient` content type.

![Captura de 2024-08-22 16-09-44](https://github.com/user-attachments/assets/f629ae21-2d0b-4835-8cf1-82cb826e8886)


## Current behavior before PR

No "Estimated birthdate" field for `Patient` content type

## Desired behavior after PR is merged

"Estimated birthdate" field for `Patient` content type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
