### PR TITLE
Fix APIError: Expected string type in samples listing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- #116 Fix APIError: Expected string type in samples listing
 - #115 Fix non-latin names and MRNs comparison in a listing view
 - #114 Fix jsonapi returns None for sample's DateOfBirth field
 - #113 Added estimated birthdate field to Patient content type

--- a/src/senaite/patient/adapters/listing.py
+++ b/src/senaite/patient/adapters/listing.py
@@ -105,8 +105,11 @@ class SamplesListingAdapter(object):
             after_icons += self.icon_tag("id-card-red", **kwargs)
             item["after"].update({"getId": after_icons})
 
-        sample_patient_mrn = api.to_utf8(obj.getMedicalRecordNumberValue)
-        sample_patient_fullname = api.to_utf8(obj.getPatientFullName)
+        sample_patient_mrn = api.to_utf8(
+            obj.getMedicalRecordNumberValue, default="")
+
+        sample_patient_fullname = api.to_utf8(
+            obj.getPatientFullName, default="")
 
         item["MRN"] = sample_patient_mrn
         item["Patient"] = sample_patient_fullname


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that arises in samples listing when the sample does not have a MRN value set. Note [`getMedicalRecordNumberValue` accessor returns `None` if there is no value set for the field](https://github.com/senaite/senaite.patient/blob/77d6dcbc80a8a2440b1b7cdf8898e122ebe3e949/src/senaite/patient/monkeys/content/analysisrequest.py#L44).

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 246, in __call__
  Module senaite.app.listing.ajax, line 113, in handle_subpath
  Module senaite.core.decorators, line 40, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 383, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 259, in get_folderitems
  Module senaite.app.listing.view, line 988, in folderitems
  Module senaite.patient, line 56, in wrapper
  Module senaite.patient.adapters.listing, line 108, in folder_item
  Module bika.lims.api, line 1949, in to_utf8
  Module bika.lims.api, line 477, in fail
APIError: Expected string type, got '<type 'NoneType'>'
```

## Desired behavior after PR is merged

No error in samples listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
