### PR TITLE
Make accessor and mutator from Patient to rely on base class

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- #117 Make accessor and mutator from Patient to rely on base class
 - #116 Fix APIError: Expected string type in samples listing
 - #115 Fix non-latin names and MRNs comparison in a listing view
 - #114 Fix jsonapi returns None for sample's DateOfBirth field

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -442,24 +442,6 @@ class Patient(Container):
 
     security = ClassSecurityInfo()
 
-    @security.private
-    def accessor(self, fieldname):
-        """Return the field accessor for the fieldname
-        """
-        schema = api.get_schema(self)
-        if fieldname not in schema:
-            return None
-        return schema[fieldname].get
-
-    @security.private
-    def mutator(self, fieldname):
-        """Return the field mutator for the fieldname
-        """
-        schema = api.get_schema(self)
-        if fieldname not in schema:
-            return None
-        return schema[fieldname].set
-
     @security.protected(permissions.View)
     def Title(self):
         return self.getFullname()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the Patient's content accessor and mutator to rely on the core's base class instead of implemeting their own. Main reason is that base class takes fields from behaviors into account, while the current implementation doesn't. 

The Patient was migrated to folderish Content on https://github.com/senaite/senaite.patient/pull/24 . However, legacy accessor and mutator were kept.

## Current behavior before PR

Get an error when adding a new behavior relying on `context.accessor`

```python
@security.protected(permissions.View)
def getConsentSMS(self):
    accessor = self.context.accessor("consent_sms")
    return accessor(self.context)
```

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.autoform.view, line 40, in __call__
  Module plone.autoform.view, line 50, in _update
  Module z3c.form.form, line 136, in updateWidgets
  Module z3c.form.field, line 277, in update
  Module z3c.form.browser.checkbox, line 63, in update
  Module z3c.form.browser.widget, line 171, in update
  Module z3c.form.widget, line 234, in update
  Module Products.CMFPlone.patches.z3c_form, line 47, in _wrapped
  Module z3c.form.widget, line 106, in update
  Module z3c.form.datamanager, line 76, in query
  Module z3c.form.datamanager, line 71, in get
  Module my.lims.behaviors.patient, line 37, in getConsentSMS
TypeError: 'NoneType' object is not callable
```

## Desired behavior after PR is merged

No error and the value of the field is returned properly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
