### PR TITLE
Remove patient-specific settings, catalogs and objects on uninstall

### DIFF
--- a/src/senaite/patient/configure.zcml
+++ b/src/senaite/patient/configure.zcml
@@ -3,7 +3,8 @@
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:cmf="http://namespaces.zope.org/cmf"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <five:registerPackage package="." initialize=".initialize"/>
 
@@ -60,7 +61,7 @@
       name="senaite.patient.vocabularies.name_entry_modes" />
 
   <!-- Package includes -->
-  <include package=".adapters" />
+  <include package=".adapters" zcml:condition="installed senaite.patient"/>
   <include package=".browser" />
   <include package=".catalog" />
   <include package=".content" />

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -43,6 +43,7 @@ from senaite.core.z3cform.widgets.datagrid import DataGridWidgetFactory
 from senaite.core.z3cform.widgets.datetimewidget import DatetimeWidget
 from senaite.core.z3cform.widgets.phone import PhoneWidgetFactory
 from senaite.patient import api as patient_api
+from senaite.patient import is_installed
 from senaite.patient import messageFactory as _
 from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.config import GENDERS
@@ -438,7 +439,15 @@ class IPatientSchema(model.Schema):
 class Patient(Container):
     """Results Interpretation Template content
     """
-    _catalogs = [PATIENT_CATALOG]
+
+    # XXX prevents a APIError: No tool named 'senaite_catalog_patient' found
+    #     when uninstalling senaite.patient product.
+    #     To remove when `catalog_mappings` is used instead
+    #     See https://github.com/senaite/senaite.core/pull/2662
+    if is_installed():
+        _catalogs = [PATIENT_CATALOG]
+    else:
+        _catalogs = []
 
     security = ClassSecurityInfo()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that `senaite.patient` product can be uninstalled cleanly.

## Current behavior before PR

Artifacts and data specific of `senaite.patient` are present after uninstall

## Desired behavior after PR is merged

Artifacts and data specific of `senaite.patient are not present after uninstall

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
