### PR TITLE
Rely on `catalog_mappings` to get the catalogs for Patient portal type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- #119 Rely on `catalog_mappings` to get the catalogs for Patient portal type
 - #117 Make accessor and mutator from Patient to rely on base class
 - #116 Fix APIError: Expected string type in samples listing
 - #115 Fix non-latin names and MRNs comparison in a listing view

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -438,6 +438,9 @@ class IPatientSchema(model.Schema):
 class Patient(Container):
     """Results Interpretation Template content
     """
+
+    # XXX Remove after 1.5.0
+    #     See https://github.com/senaite/senaite.patient/pull/119
     _catalogs = [PATIENT_CATALOG]
 
     security = ClassSecurityInfo()

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1502</version>
+  <version>1503</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/setuphandlers.py
+++ b/src/senaite/patient/setuphandlers.py
@@ -43,6 +43,11 @@ CATALOGS = (
     PatientCatalog,
 )
 
+# Tuples of (portal_type, [catalog_id,])
+CATALOG_MAPPINGS = (
+    ("Patient", [PATIENT_CATALOG]),
+)
+
 # Tuples of (catalog, index_name, index_attribute, index_type)
 INDEXES = [
     (SAMPLE_CATALOG, "is_temporary_mrn", "", "BooleanIndex"),
@@ -168,6 +173,9 @@ def setup_handler(context):
     logger.info("{} setup handler [BEGIN]".format(PRODUCT_NAME.upper()))
     portal = context.getSite()
 
+    # Setup catalogs
+    setup_catalogs(portal)
+
     # Setup catalog mappings
     setup_catalog_mappings(portal)
 
@@ -176,9 +184,6 @@ def setup_handler(context):
 
     # Configure visible navigation items
     setup_navigation_types(portal)
-
-    # Setup catalogs
-    setup_catalogs(portal)
 
     # Apply ID format to content types
     setup_id_formatting(portal)
@@ -399,8 +404,6 @@ def setup_catalog_mappings(portal):
     """Setup the catalog mappings for portal types in senaite registry
     """
     logger.info("Setup catalog mappings ...")
-
-    # setup catalog mappings for Patient DX
-    set_catalogs("Patient", [PATIENT_CATALOG])
-
+    for portal_type, catalogs in CATALOG_MAPPINGS:
+        set_catalogs(portal_type, catalogs)
     logger.info("Setup catalog mappings [DONE]")

--- a/src/senaite/patient/setuphandlers.py
+++ b/src/senaite/patient/setuphandlers.py
@@ -22,12 +22,14 @@ from bika.lims import api
 from plone.registry.interfaces import IRegistry
 from Products.DCWorkflow.Guard import Guard
 from senaite.core.catalog import SAMPLE_CATALOG
+from senaite.core.catalog import set_catalogs
 from senaite.core.setuphandlers import setup_core_catalogs
 from senaite.core.setuphandlers import setup_other_catalogs
 from senaite.core.workflow import SAMPLE_WORKFLOW
-from senaite.patient import PRODUCT_NAME
 from senaite.patient import logger
 from senaite.patient import permissions
+from senaite.patient import PRODUCT_NAME
+from senaite.patient.catalog import PATIENT_CATALOG
 from senaite.patient.catalog.patient_catalog import PatientCatalog
 from zope.component import getUtility
 
@@ -166,7 +168,10 @@ def setup_handler(context):
     logger.info("{} setup handler [BEGIN]".format(PRODUCT_NAME.upper()))
     portal = context.getSite()
 
-    # Setup patient content type
+    # Setup catalog mappings
+    setup_catalog_mappings(portal)
+
+    # Setup patients root folder
     add_patient_folder(portal)
 
     # Configure visible navigation items
@@ -388,3 +393,14 @@ def update_workflow_transition(workflow, transition_id, settings):
     guard_props = settings.get("guard", guard_props)
     guard.changeFromProperties(guard_props)
     transition.guard = guard
+
+
+def setup_catalog_mappings(portal):
+    """Setup the catalog mappings for portal types in senaite registry
+    """
+    logger.info("Setup catalog mappings ...")
+
+    # setup catalog mappings for Patient DX
+    set_catalogs("Patient", [PATIENT_CATALOG])
+
+    logger.info("Setup catalog mappings [DONE]")

--- a/src/senaite/patient/upgrade/v01_05_000.py
+++ b/src/senaite/patient/upgrade/v01_05_000.py
@@ -24,7 +24,6 @@ from senaite.patient import logger
 from senaite.patient.config import PRODUCT_NAME
 from senaite.patient.setuphandlers import setup_catalog_mappings
 from senaite.patient.setuphandlers import setup_catalogs
-from senaite.patient.setuphandlers import setup_senaite_registry
 
 version = "1.5.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)

--- a/src/senaite/patient/upgrade/v01_05_000.py
+++ b/src/senaite/patient/upgrade/v01_05_000.py
@@ -22,7 +22,9 @@ from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.patient import logger
 from senaite.patient.config import PRODUCT_NAME
+from senaite.patient.setuphandlers import setup_catalog_mappings
 from senaite.patient.setuphandlers import setup_catalogs
+from senaite.patient.setuphandlers import setup_senaite_registry
 
 version = "1.5.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)
@@ -69,3 +71,10 @@ def import_registry(tool):
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, "plone.app.registry")
     logger.info("Reimport registry tool [DONE]")
+
+
+def update_catalog_mappings(tool):
+    """Updates the catalog mappings of senaite registry
+    """
+    portal = tool.aq_inner.aq_parent
+    setup_catalog_mappings(portal)

--- a/src/senaite/patient/upgrade/v01_05_000.zcml
+++ b/src/senaite/patient/upgrade/v01_05_000.zcml
@@ -2,6 +2,17 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
+  <!-- 1503: Use senaite registry for catalog mappings  -->
+  <genericsetup:upgradeStep
+      title="Use senaite registry for catalog mappings"
+      description="
+        This upgrade step adds the catalog mappings for patient in senaite
+        registry instead of relying on a `_catalog` attribute in DX object"
+      source="1502"
+      destination="1503"
+      handler=".v01_05_000.setup_senaite_registry"
+      profile="senaite.patient:default"/>
+
   <!-- 1502: Allow/Disallow future dates of birth -->
   <genericsetup:upgradeStep
       title="Add setting to allow/disallow future dates of birth"

--- a/src/senaite/patient/upgrade/v01_05_000.zcml
+++ b/src/senaite/patient/upgrade/v01_05_000.zcml
@@ -10,7 +10,7 @@
         registry instead of relying on a `_catalog` attribute in DX object"
       source="1502"
       destination="1503"
-      handler=".v01_05_000.setup_senaite_registry"
+      handler=".v01_05_000.update_catalog_mappings"
       profile="senaite.patient:default"/>
 
   <!-- 1502: Allow/Disallow future dates of birth -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]
> Merge https://github.com/senaite/senaite.core/pull/2681 first!

This Pull Request makes this product compatible with https://github.com/senaite/senaite.core/pull/2662

## Current behavior before PR

System relies on `_catalogs` attribute from `Patient` content type to know the catalogs to use

## Desired behavior after PR is merged

System relies on `catalog_mappings` from registry to know the catalogs to use

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
