### PR TITLE
Hyperlinked Patient on Sample listing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- #123 Hyperlink patient on sample listing
 - #119 Rely on `catalog_mappings` to get the catalogs for Patient portal type
 - #117 Make accessor and mutator from Patient to rely on base class
 - #116 Fix APIError: Expected string type in samples listing

--- a/src/senaite/patient/adapters/listing.py
+++ b/src/senaite/patient/adapters/listing.py
@@ -141,6 +141,11 @@ class SamplesListingAdapter(object):
             val = api.safe_unicode(patient_fullname) or _("<no value>")
             icon_args = {"width": 16, "title": api.to_utf8(msg % val)}
             item["after"]["Patient"] = self.icon_tag("info", **icon_args)
+        else:
+            patient_view_url = "{}/@@view".format(patient_url)
+            patient_view_url = get_link(
+                    patient_view_url, sample_patient_fullname)
+            item["Patient"] = patient_view_url
 
     @viewcache
     def get_patient_by_mrn(self, mrn):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.patient/issues/122

## Current behavior before PR
Patient is not hyperlinked on the Samples listing
![image-20231109-074309](https://github.com/user-attachments/assets/0c3a29c8-ff62-46a5-a7af-846d383b2445)

## Desired behavior after PR is merged
Patient to be hyperlinked
![image](https://github.com/user-attachments/assets/8b337719-5a08-4206-9680-358f9765f4c6)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
