### PR TITLE
Add Age field for patient content

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 1.5.0 (2025-04-04)
 ------------------
 
+- #125 Add Age field for patient content
 - #123 Hyperlink patient on sample listing
 - #119 Rely on `catalog_mappings` to get the catalogs for Patient portal type
 - #117 Make accessor and mutator from Patient to rely on base class

--- a/src/senaite/patient/adapters/configure.zcml
+++ b/src/senaite/patient/adapters/configure.zcml
@@ -53,5 +53,11 @@
          senaite.patient.interfaces.IPatient"
     provides="senaite.app.listing.interfaces.IListingViewAdapter"
     factory=".listing.SamplesListingAdapter" />
+  
+  <!-- Edit form handler for Patient -->
+  <adapter
+      for="senaite.patient.interfaces.IPatient
+           senaite.patient.interfaces.ISenaitePatientLayer"
+      factory=".form.PatientEditForm"/>
 
 </configure>

--- a/src/senaite/patient/adapters/form.py
+++ b/src/senaite/patient/adapters/form.py
@@ -72,7 +72,7 @@ class PatientEditForm(EditFormAdapterBase):
             self.add_hide_field(BIRTHDATE_FIELDS[0])
         else:
             age = form.get(AGE_FIELD)
-            if age:
+            if dtime.is_ymd(age):
                 self.update_birthdate_field_from_age(age)
             self.add_show_field(BIRTHDATE_FIELDS[0])
             self.add_hide_field(AGE_FIELD)

--- a/src/senaite/patient/adapters/form.py
+++ b/src/senaite/patient/adapters/form.py
@@ -46,7 +46,9 @@ class PatientEditForm(EditFormAdapterBase):
     def modified(self, data):
         if data.get("name") == ESTIMATED_BIRTHDATE_FIELDS[0]:
             estimated_birthdate = data.get("value")
-            self.toggle_and_update_fields(data.get("form"), estimated_birthdate)
+            self.toggle_and_update_fields(
+                data.get("form"), estimated_birthdate
+            )
         return self.data
 
     def update_age_field_from_birthdate(self, birthdate):

--- a/src/senaite/patient/adapters/form.py
+++ b/src/senaite/patient/adapters/form.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.PATIENT.
+#
+# SENAITE.PATIENT is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from datetime import date
+from senaite.core.api import dtime
+from senaite.core.browser.form.adapters import EditFormAdapterBase
+
+
+ESTIMATED_BIRTHDATE_FIELDS = (
+    "form.widgets.estimated_birthdate",
+    "form.widgets.estimated_birthdate:list"
+)
+AGE_FIELD = "form.widgets.age"
+BIRTHDATE_FIELDS = (
+    "form.widgets.birthdate",
+    "form.widgets.birthdate-date"
+)
+
+
+class PatientEditForm(EditFormAdapterBase):
+    """Edit form for Patient content type
+    """
+
+    def initialized(self, data):
+        form = data.get("form")
+        estimated_birthdate = form.get(ESTIMATED_BIRTHDATE_FIELDS[1])
+        self.toggle_and_update_fields(form, estimated_birthdate)
+        return self.data
+
+    def modified(self, data):
+        if data.get("name") == ESTIMATED_BIRTHDATE_FIELDS[0]:
+            estimated_birthdate = data.get("value")
+            self.toggle_and_update_fields(data.get("form"), estimated_birthdate)
+        return self.data
+
+    def update_age_field_from_birthdate(self, birthdate):
+        age = dtime.get_ymd(birthdate, dt2=date.today())
+        self.add_update_field(AGE_FIELD, age)
+
+    def update_birthdate_field_from_age(self, age):
+        birthdate = dtime.get_since_date(age)
+        birthdate_str = birthdate.strftime("%Y-%m-%d") if birthdate else ""
+        for field in BIRTHDATE_FIELDS:
+            self.add_update_field(field, birthdate_str)
+
+    def toggle_and_update_fields(self, form, estimated_birthdate):
+        """Toggle age and birthdate fields that depend on estimated_birthdate
+        """
+        if estimated_birthdate is True or estimated_birthdate == "selected":
+            birthdate = form.get(BIRTHDATE_FIELDS[0])
+            if birthdate:
+                self.update_age_field_from_birthdate(birthdate)
+            self.add_show_field(AGE_FIELD)
+            self.add_hide_field(BIRTHDATE_FIELDS[0])
+        else:
+            age = form.get(AGE_FIELD)
+            if age:
+                self.update_birthdate_field_from_age(age)
+            self.add_show_field(BIRTHDATE_FIELDS[0])
+            self.add_hide_field(AGE_FIELD)

--- a/src/senaite/patient/adapters/form.py
+++ b/src/senaite/patient/adapters/form.py
@@ -18,7 +18,6 @@
 # Copyright 2020-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from datetime import date
 from senaite.core.api import dtime
 from senaite.core.browser.form.adapters import EditFormAdapterBase
 
@@ -51,19 +50,19 @@ class PatientEditForm(EditFormAdapterBase):
         return self.data
 
     def update_age_field_from_birthdate(self, birthdate):
-        age = dtime.get_ymd(birthdate, dt2=date.today())
+        age = dtime.get_ymd(birthdate)
         self.add_update_field(AGE_FIELD, age)
 
     def update_birthdate_field_from_age(self, age):
         birthdate = dtime.get_since_date(age)
-        birthdate_str = birthdate.strftime("%Y-%m-%d") if birthdate else ""
+        birthdate_str = dtime.date_to_string(birthdate)
         for field in BIRTHDATE_FIELDS:
             self.add_update_field(field, birthdate_str)
 
     def toggle_and_update_fields(self, form, estimated_birthdate):
         """Toggle age and birthdate fields that depend on estimated_birthdate
         """
-        if estimated_birthdate is True or estimated_birthdate == "selected":
+        if estimated_birthdate in [True, "selected"]:
             birthdate = form.get(BIRTHDATE_FIELDS[0])
             if birthdate:
                 self.update_age_field_from_birthdate(birthdate)

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -303,18 +303,6 @@ class IPatientSchema(model.Schema):
         ]
     )
 
-    directives.widget("birthdate",
-                      DatetimeWidget,
-                      show_time=False)
-    birthdate = DatetimeField(
-        title=_(u"label_patient_birthdate", default=u"Birthdate"),
-        description=_(u"Patient birthdate"),
-        required=False,
-    )
-    # XXX core's DateTimeWidget relies on field's get_max function if not 'max'
-    #     property is explicitly set to the widget
-    birthdate.get_max = get_max_birthdate
-
     estimated_birthdate = schema.Bool(
         title=_(
             u"label_patient_estimated_birthdate",
@@ -328,6 +316,18 @@ class IPatientSchema(model.Schema):
         default=False,
         required=False,
     )
+
+    directives.widget("birthdate",
+                      DatetimeWidget,
+                      show_time=False)
+    birthdate = DatetimeField(
+        title=_(u"label_patient_birthdate", default=u"Birthdate"),
+        description=_(u"Patient birthdate"),
+        required=False,
+    )
+    # XXX core's DateTimeWidget relies on field's get_max function if not 'max'
+    #     property is explicitly set to the widget
+    birthdate.get_max = get_max_birthdate
 
     age = schema.TextLine(
         title=_(u"label_patient_age", default=u"Age"),

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -834,16 +834,23 @@ class Patient(Container):
 
     @security.protected(permissions.View)
     def getAge(self):
-        """Returns the age with the field accessor
+        """Returns the age of the patient at current time
         """
-        accessor = self.accessor("age")
-        return accessor(self)
+        dob = self.getBirthdate()
+        return dtime.get_ymd(dob) or ""
 
     @security.protected(permissions.ModifyPortalContent)
     def setAge(self, value):
-        """Set the age with the field accessor
+        """Set the age of the patient at current time
         """
-        mutator = self.mutator("age")
-        return mutator(self, value)
+        if not dtime.is_ymd(value):
+            return
 
+        dob = dtime.get_since_date(value)
+        self.setEstimatedBirthdate(True)
+        self.setBirthdate(dob)
+
+    # BBB AT schema field property
     Age = property(getAge, setAge)
+
+    age = property(getAge, setAge)

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -333,7 +333,10 @@ class IPatientSchema(model.Schema):
         title=_(u"label_patient_age", default=u"Age"),
         description=_(
             u"description_patient_age",
-            default=u"Age in YMD format"
+            default=_(
+                u"Age in YMD (Years-Months-Days) format. "
+                u"Examples: '45y 3m 20d', '67y'."
+            )
         ),
         required=False,
     )

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -846,11 +846,16 @@ class Patient(Container):
         if not dtime.is_ymd(value):
             return
 
+        # don't assign age unless estimated DoB
+        if not self.getEstimatedBirthdate():
+            return
+
+        # update the value of the date of birth
         dob = dtime.get_since_date(value)
-        self.setEstimatedBirthdate(True)
         self.setBirthdate(dob)
 
     # BBB AT schema field property
     Age = property(getAge, setAge)
 
+    # no value is stored for age, but relies on birthdate
     age = property(getAge, setAge)

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -333,7 +333,7 @@ class IPatientSchema(model.Schema):
         title=_(u"label_patient_age", default=u"Age"),
         description=_(
             u"description_patient_age",
-            default=u"Age in YMD format or a single number representing years"
+            default=u"Age in YMD format"
         ),
         required=False,
     )
@@ -444,12 +444,12 @@ class IPatientSchema(model.Schema):
 
     @invariant
     def validate_age(data):
-        """Validate the age is in YMD format or a valid year."""
+        """Validate the age is in YMD format."""
         if not data.age:
             return
 
         if not dtime.is_ymd(data.age):
-            raise Invalid(_("Age must be in YMD format or a valid year"))
+            raise Invalid(_("Age must be in YMD format"))
 
 
 @implementer(IPatient, IPatientSchema, IClientShareable)


### PR DESCRIPTION
> [!WARNING]
> Requirements:
> - https://github.com/senaite/senaite.core/pull/2695
> - https://github.com/senaite/senaite.core/pull/2705

## Description of the issue/feature this PR addresses

This Pull Request adds age field and toggles age and birthdate field based on estimate birthday field

## Current behavior before PR

- The Patient content type does not support inputting age directly.
- Users are required to enter a birthdate, even if the birthdate is only estimated or unknown.

## Desired behavior after PR is merged

- A new field Age is added to the Patient content type.
- The user can input age either in: 
  - A single number representing the number of years (e.g., 32y), or
  - A structured format like Xy Ym Zd (e.g., 5y 2m 10d) — if supported.
- When the user selects the checkbox "Birthdate is estimated", the birthdate field becomes hidden and the Age field becomes visible

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
