### PR TITLE
Add adapter for patient add views

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,9 @@ Changelog
 1.6.0 (unreleased)
 ------------------
 
-- #121 Compatibility with core#2695 (relativedelta and ymd in api.dtime)
+- #127 Add adapter for patient add views
 - #125 Add Age field for patient content
+- #121 Compatibility with core#2695 (relativedelta and ymd in api.dtime)
 
 
 1.5.0 (2025-04-04)

--- a/src/senaite/patient/adapters/configure.zcml
+++ b/src/senaite/patient/adapters/configure.zcml
@@ -53,8 +53,15 @@
          senaite.patient.interfaces.IPatient"
     provides="senaite.app.listing.interfaces.IListingViewAdapter"
     factory=".listing.SamplesListingAdapter" />
+
+  <!-- Patient: add form handler -->
+  <adapter
+      for="*
+           senaite.patient.interfaces.ISenaitePatientLayer"
+      name="++add++Patient"
+      factory=".form.PatientEditForm"/>
   
-  <!-- Edit form handler for Patient -->
+  <!-- Patient: edit form handler -->
   <adapter
       for="senaite.patient.interfaces.IPatient
            senaite.patient.interfaces.ISenaitePatientLayer"

--- a/src/senaite/patient/browser/patient/views.py
+++ b/src/senaite/patient/browser/patient/views.py
@@ -45,7 +45,7 @@ def fiddle_schema_fields(fields):
 
 
 class PatientAddForm(DefaultAddForm):
-    """Patient edit view
+    """Patient add view
     """
     portal_type = "Patient"
     default_fieldset_label = _("label_schema_personal", default=u"Personal")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This PR implements a form adapter for the Patient add view that handles the toggle between birthdate and age fields

## Current behavior before PR
- No field visibility toggling between age and birthdate for Patient add view

## Desired behavior after PR is merged
- Can toggle between age and birthdate for Patient add view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
