### PR TITLE
Add modified index to Patient catalog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.6.0 (unreleased)
 ------------------
 
+- #128 Add modified index to Patient catalog
 - #127 Add adapter for patient add views
 - #125 Add Age field for patient content
 - #121 Compatibility with core#2695 (relativedelta and ymd in api.dtime)

--- a/src/senaite/patient/catalog/patient_catalog.py
+++ b/src/senaite/patient/catalog/patient_catalog.py
@@ -43,6 +43,7 @@ INDEXES = BASE_INDEXES + [
     ("patient_searchable_text", "", "ZCTextIndex"),
     ("patient_searchable_mrn", "", "ZCTextIndex"),
     ("patient_deceased", "", "BooleanIndex"),
+    ("modified", "", "DateIndex"),
 ]
 
 COLUMNS = BASE_COLUMNS + [

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1600</version>
+  <version>1601</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/upgrade/v01_06_000.py
+++ b/src/senaite/patient/upgrade/v01_06_000.py
@@ -22,6 +22,7 @@ from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.patient import logger
 from senaite.patient.config import PRODUCT_NAME
+from senaite.patient.setuphandlers import setup_catalog_mappings
 
 version = "1.6.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)
@@ -46,3 +47,11 @@ def upgrade(tool):
 
     logger.info("{0} upgraded to version {1}".format(PRODUCT_NAME, version))
     return True
+
+
+@upgradestep(PRODUCT_NAME, version)
+def upgrade_catalog_modified_index(tool):
+    logger.info("Upgrade catalog modified index ...")
+    portal = tool.aq_inner.aq_parent
+    # setup patient catalog to add new indexes
+    setup_catalog_mappings(portal)

--- a/src/senaite/patient/upgrade/v01_06_000.zcml
+++ b/src/senaite/patient/upgrade/v01_06_000.zcml
@@ -1,6 +1,13 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+  
+  <genericsetup:upgradeStep
+      title="Add modified index to patient catalog"
+      source="1600"
+      destination="1601"
+      handler=".v01_06_000.upgrade_catalog_modified_index"
+      profile="senaite.patient:default"/>
 
   <genericsetup:upgradeStep
       title="Upgrade to SENAITE.PATIENT 1.6.0"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Add modified index to Patient catalog

## Current behavior before PR
Don't have modified index in Patient catalog -> cannot search by modified field

## Desired behavior after PR is merged
Have modified index in Patient catalog -> can search by modified field

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
