### PR TITLE
Fix Patient invariant validation for MRN and birthdate field

### DIFF
--- a/src/senaite/patient/api.py
+++ b/src/senaite/patient/api.py
@@ -355,7 +355,7 @@ def is_patient_creation_allowed(container):
     return api.security.check_permission(AddPatient, container)
 
 
-def is_mrn_unique(mrn):
+def is_mrn_unique(mrn, uid=None):
     """Checks whether the mrn provided is unique. This is, no patients with
     this mrn exist, regardless of their status
 
@@ -367,4 +367,11 @@ def is_mrn_unique(mrn):
         "patient_mrn": api.safe_unicode(mrn).encode("utf8"),
     }
     brains = api.search(query, PATIENT_CATALOG)
-    return len(brains) == 0
+
+    if len(brains) == 0:
+        return True
+
+    if uid and api.get_uid(brains[0]) == uid:
+        return True
+
+    return False

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -375,7 +375,7 @@ class IPatientSchema(model.Schema):
             return
 
         # search for uniqueness
-        if not patient_api.is_mrn_unique(data.mrn):
+        if not patient_api.is_mrn_unique(data.mrn, api.get_uid(data)):
             raise Invalid(
                 _("invalid_patient_mrn_must_be_unique",
                   default="Patient Medical Record Number must be unique"))
@@ -432,7 +432,7 @@ class IPatientSchema(model.Schema):
             return
 
         # check if field is in current fieldset to avoid multiple raising
-        if 'birthdate' not in data._Data_data___:
+        if 'birthdate' not in data.__dict__:
             return
 
         if patient_api.is_future_birthdate_allowed():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This PR fixes MRN uniqueness validation during validateInvariants and corrects the birthdate check by using `__dict__` instead of `_Data_data___`.

## Current behavior before PR
- MRN uniqueness check fails if the MRN is already set, preventing new Patients from being created with valid MRNs.
- Accessing _Data_data___ can raise an AttributeError when checking for birthdate.

## Desired behavior after PR is merged
- MRN uniqueness validation runs correctly, allowing creation of Patients with unique MRNs.
- Birthdate check no longer raises an AttributeError.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
