### PR TITLE
Remove email invariant and add adapter to toggle email_report

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.6.0 (unreleased)
 ------------------
 
+- #133 Enhance email extraction in IPatientSchema to support JSON request body
 - #131 Fix BehaviorRegistrationNotFound on Patient creation via JSON API
 - #130 Fix cannot search samples by MRN or patient name
 - #127 Add adapter for patient add views

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 1.6.0 (unreleased)
 ------------------
 
-- #133 Enhance email extraction in IPatientSchema to support JSON request body
+- #133 Remove email invariant and add adapter to toggle email_report
 - #131 Fix BehaviorRegistrationNotFound on Patient creation via JSON API
 - #130 Fix cannot search samples by MRN or patient name
 - #127 Add adapter for patient add views

--- a/src/senaite/patient/adapters/form.py
+++ b/src/senaite/patient/adapters/form.py
@@ -18,19 +18,22 @@
 # Copyright 2020-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims.api.mail import is_valid_email_address
 from senaite.core.api import dtime
 from senaite.core.browser.form.adapters import EditFormAdapterBase
 
-
-ESTIMATED_BIRTHDATE_FIELDS = (
-    "form.widgets.estimated_birthdate",
-    "form.widgets.estimated_birthdate:list"
-)
+ESTIMATED_BIRTHDATE_FIELD = "form.widgets.estimated_birthdate:list"
 AGE_FIELD = "form.widgets.age"
 BIRTHDATE_FIELDS = (
     "form.widgets.birthdate",
     "form.widgets.birthdate-date"
 )
+BIRTHDATE_FIELD = "form.widgets.birthdate"
+EMAIL_FIELD = "form.widgets.email"
+EMAIL_REPORT_FIELDS = [
+    "form.widgets.email_report",
+    "form.widgets.email_report-empty-marker"
+]
 
 
 class PatientEditForm(EditFormAdapterBase):
@@ -39,16 +42,11 @@ class PatientEditForm(EditFormAdapterBase):
 
     def initialized(self, data):
         form = data.get("form")
-        estimated_birthdate = form.get(ESTIMATED_BIRTHDATE_FIELDS[1])
-        self.toggle_and_update_fields(form, estimated_birthdate)
+        self.toggle_and_update_fields(form)
         return self.data
 
     def modified(self, data):
-        if data.get("name") == ESTIMATED_BIRTHDATE_FIELDS[0]:
-            estimated_birthdate = data.get("value")
-            self.toggle_and_update_fields(
-                data.get("form"), estimated_birthdate
-            )
+        self.toggle_and_update_fields(data.get("form"))
         return self.data
 
     def update_age_field_from_birthdate(self, birthdate):
@@ -61,9 +59,10 @@ class PatientEditForm(EditFormAdapterBase):
         for field in BIRTHDATE_FIELDS:
             self.add_update_field(field, birthdate_str)
 
-    def toggle_and_update_fields(self, form, estimated_birthdate):
-        """Toggle age and birthdate fields that depend on estimated_birthdate
+    def toggle_and_update_fields(self, form):
+        """Toggle patient fields
         """
+        estimated_birthdate = form.get(ESTIMATED_BIRTHDATE_FIELD)
         if estimated_birthdate in [True, "selected"]:
             birthdate = form.get(BIRTHDATE_FIELDS[0])
             if birthdate:
@@ -76,3 +75,9 @@ class PatientEditForm(EditFormAdapterBase):
                 self.update_birthdate_field_from_age(age)
             self.add_show_field(BIRTHDATE_FIELDS[0])
             self.add_hide_field(AGE_FIELD)
+
+        email = form.get(EMAIL_FIELD)
+        if email and is_valid_email_address(email):
+            self.add_show_field(EMAIL_REPORT_FIELDS[0])
+        else:
+            self.add_hide_field(EMAIL_REPORT_FIELDS[1])

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -18,7 +18,6 @@
 # Copyright 2020-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-import json
 from string import Template
 
 from AccessControl import ClassSecurityInfo

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -101,6 +101,7 @@ class IPatientSchema(model.Schema):
         label=u"Email and Phone",
         fields=[
             "email",
+            "email_report",
             "additional_emails",
             "phone",
             "additional_phone_numbers",

--- a/src/senaite/patient/content/patient.py
+++ b/src/senaite/patient/content/patient.py
@@ -382,53 +382,6 @@ class IPatientSchema(model.Schema):
                   default="Patient Medical Record Number must be unique"))
 
     @invariant
-    def validate_email_report(data):
-        """Checks if an email is set
-        """
-        value = data.email_report
-        if not value:
-            return
-
-        # check if a valid email is in the request
-        # Note: Workaround for missing `data.email`
-        request = api.get_request()
-        form_data = request.form or {}
-
-        def extract_email(form_data, request):
-            # Get from form widgets
-            email = form_data.get("form.widgets.email")
-            if email:
-                return email
-
-            # Get from request BODY
-            try:
-                body = json.loads(request.get("BODY", "{}"))
-            except Exception:
-                return None
-
-            # Get from body.email
-            if body.get("email"):
-                return body["email"]
-
-            # Get from body.items[0].email
-            items = body.get("items", [])
-            if items and isinstance(items, list):
-                return items[0].get("email")
-
-            return None
-
-        email = extract_email(form_data, request)
-        if email and is_valid_email_address(email):
-            return
-
-        # mark the request to avoid multiple raising
-        key = "_v_email_report_checked"
-        if getattr(request, key, False):
-            return
-        setattr(request, key, True)
-        raise Invalid(_("Please set a valid email address first"))
-
-    @invariant
     def validate_email(data):
         """Checks if the email is correct
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the `validate_email_report` invariant and replaces it with an EditFormAdapter that handles the visibility of the `email_report` field based on whether the entered email is valid. Email validation should not be part of the invariant’s responsibility.

## Current behavior before PR
The `validate_email_report` invariant attempted to validate the email by checking `request.form`, which does not work for JSON API requests and mixes responsibilities. As a result, email validation failed in API scenarios and the logic for showing/hiding `email_report` was not handled cleanly.

## Desired behavior after PR is merged

- The invariant is removed entirely.
- An `EditFormAdapter` now automatically shows the `email_report` field when the `email` field contains a valid email, and hides it otherwise.
- Behavior is consistent for both form submissions and JSON API usage

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
