### PR TITLE
Use UnorderedOrdering for PatientFolder to avoid ZODB conflicts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.6.0 (unreleased)
 ------------------
 
+- #135 Use UnorderedOrdering for PatientFolder to avoid ZODB conflicts
 - #133 Remove email invariant and add adapter to toggle email_report
 - #134 Compatibility with core#2835 (display Patients in navbar)
 - #131 Fix BehaviorRegistrationNotFound on Patient creation via JSON API

--- a/src/senaite/patient/content/configure.zcml
+++ b/src/senaite/patient/content/configure.zcml
@@ -16,4 +16,29 @@
       factory=".analysisrequest.AnalysisRequestSchemaModifier"
       provides="archetypes.schemaextender.interfaces.ISchemaModifier"/>
 
+  <!--
+    Use plone.folder's UnorderedOrdering as the IOrdering adapter for the
+    PatientFolder.
+
+    The default DefaultOrdering keeps a `plone.folder.ordered.order`
+    PersistentList annotation that grows with the number of children:
+    every `_setObject` calls `notifyAdded` which appends to the list.
+    PersistentList has no `_p_resolveConflict()`, so two concurrent
+    appends collide and the conflict propagates to the client through
+    the publisher's retry loop. On clinical-lab installations the
+    PatientFolder accumulates one Patient per registered sample, so
+    every concurrent sample-registration that creates a new Patient
+    contends on the same annotation. With tens of thousands of children
+    the cost grows roughly with the number of entries.
+
+    Patient listings never depend on the parent folder's manual
+    ordering — they sort catalog brains. Switching IPatientFolder to
+    UnorderedOrdering removes the hot-spot at no functional cost.
+    -->
+  <adapter
+      for=".patientfolder.IPatientFolder"
+      factory="plone.folder.unordered.UnorderedOrdering"
+      provides="plone.folder.interfaces.IOrdering"
+      />
+
 </configure>

--- a/src/senaite/patient/profiles/default/metadata.xml
+++ b/src/senaite/patient/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1602</version>
+  <version>1603</version>
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>
   </dependencies>

--- a/src/senaite/patient/upgrade/v01_06_000.py
+++ b/src/senaite/patient/upgrade/v01_06_000.py
@@ -24,6 +24,7 @@ from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.patient import logger
 from senaite.patient.config import PRODUCT_NAME
 from senaite.patient.setuphandlers import display_in_nav
+from zope.annotation.interfaces import IAnnotations
 
 version = "1.6.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)
@@ -76,3 +77,44 @@ def display_patients_navbar(tool):
     patients = api.get_portal().patients
     display_in_nav(patients)
     logger.info("Display Patients in navigation bar [DONE]")
+
+
+def drop_patientfolder_ordering_annotations(tool):
+    """Remove the legacy IOrdering annotations from the PatientFolder.
+
+    The PatientFolder now uses `plone.folder.unordered.UnorderedOrdering`
+    as its `IOrdering` adapter, so the previous default-ordering
+    annotations are no longer maintained:
+
+      - `plone.folder.ordered.order` — a `PersistentList` of every
+        child id, mutated on every `_setObject` via
+        `DefaultOrdering.notifyAdded`. With one Patient per registered
+        sample on a clinical-lab installation, this list grows to many
+        tens of thousands of entries; because `PersistentList` has no
+        `_p_resolveConflict()`, every concurrent registration that
+        creates a new Patient collided on it and the conflict
+        propagated all the way to the publisher's retry loop.
+
+      - `plone.folder.ordered.pos` — companion `OIBTree` mapping
+        child id -> position. No longer read by anything once the
+        adapter is unordered.
+
+    Removing both annotations after the adapter switch frees the
+    storage they occupy and removes a stale hot-mutation bucket from
+    the ZODB cache. The adapter override is what stops new writes
+    from touching them; this step is hygiene.
+    """
+    logger.info("Dropping IOrdering annotations from PatientFolder ...")
+    patients = api.get_portal().patients
+    ann = IAnnotations(patients)
+    had_order = "plone.folder.ordered.order" in ann
+    had_pos = "plone.folder.ordered.pos" in ann
+    if not (had_order or had_pos):
+        logger.info(
+            "Dropping IOrdering annotations from PatientFolder [SKIP] "
+            "(no annotations found)")
+        return
+    ann.pop("plone.folder.ordered.order", None)
+    ann.pop("plone.folder.ordered.pos", None)
+    patients._p_changed = True
+    logger.info("Dropping IOrdering annotations from PatientFolder [DONE]")

--- a/src/senaite/patient/upgrade/v01_06_000.zcml
+++ b/src/senaite/patient/upgrade/v01_06_000.zcml
@@ -3,6 +3,19 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Drop ordering annotations from PatientFolder"
+      description="
+        Remove the plone.folder.ordered.order PersistentList and
+        plone.folder.ordered.pos OIBTree annotations from the PatientFolder.
+        The folder now uses UnorderedOrdering as its IOrdering adapter, so
+        these annotations are no longer maintained and become a stale ZODB
+        conflict spot if left in place."
+      source="1602"
+      destination="1603"
+      handler=".v01_06_000.drop_patientfolder_ordering_annotations"
+      profile="senaite.patient:default"/>
+
+  <genericsetup:upgradeStep
       title="Display Patients in the navbar"
       description="
         This upgrade step makes the product compatible with senaite.core#2835


### PR DESCRIPTION
## Description
Switch the `IOrdering` adapter for `PatientFolder` from `plone.folder.default.DefaultOrdering` to `plone.folder.unordered.UnorderedOrdering`.

`PatientFolder` is folderish. With the default adapter, Plone keeps a `plone.folder.ordered.order` annotation — a flat `persistent.list.PersistentList` of every child id, mutated on every `_setObject` via `notifyAdded(obj_id)` (`order.append(...)`). `PersistentList` does not implement `_p_resolveConflict()`, so two concurrent registrations on the same folder always conflict on this single annotation OID, and the conflict propagates all the way to the publisher's 3-retry loop. The cost of each retry grows linearly with the size of the list, because `PersistentList` rewrites the whole pickle on every mutation.

For clinical-lab installations the `PatientFolder` accumulates one `Patient` per registered sample, so its child count grows on the same trajectory as the sample volume — into the tens or hundreds of thousands. Concurrent sample registration is exactly the workload that maximises contention on this single annotation: every new Patient created during sample-add hits the same `order.append`.

With `UnorderedOrdering` the adapter's `notifyAdded`/`notifyRemoved` become no-ops; `idsInOrder()` falls back to `aq_base(folder).objectIds(ordered=False)`, which reads the BTreeFolder2 internal tree (scales, has built-in conflict resolution).

The change is interface-scoped to `IPatientFolder` only. `Patient` content (which is itself folderish) and any other folderish type provided by senaite.patient are unaffected — they continue to use `DefaultOrdering`.

Patient listings never depend on the parent folder's manual ordering — they sort catalog brains. An audit of the package found only upgrade-step iterations over `portal.patients.objectValues()`, none of which assume insertion order.

## Migration

Existing `PatientFolder` instances still carry the `plone.folder.ordered.order` `PersistentList` and `plone.folder.ordered.pos` `OIBTree` annotations from prior writes. They are no longer maintained but remain on disk. The new upgrade step `drop_patientfolder_ordering_annotations` (profile version `1602 → 1603`) pops both annotations from `portal.patients`.

The adapter override is what stops new writes from touching the annotations; the upgrade step is hygiene to free their storage.

## Related

This follows the same pattern proposed upstream in senaite/senaite.core (PR for `IClient` → `UnorderedOrdering`): [Use UnorderedOrdering for Clients to avoid ZODB conflicts #2897](https://github.com/senaite/senaite.core/pull/2897). Both folders share the same growth profile under high concurrent sample-registration load.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
